### PR TITLE
remove file parameter from assert macros

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -2,26 +2,26 @@
 #define _H_MACROS_
 
 #ifdef DEBUG
-#define ASSERTLINE(file, line, cond) \
-    ((cond) || (OSPanic(file, line, "Failed assertion " #cond), 0))
+#define ASSERTLINE(line, cond) \
+    ((cond) || (OSPanic(__FILE__, line, "Failed assertion " #cond), 0))
 
-#define ASSERTMSGLINE(file, line, cond, msg) \
-    ((cond) || (OSPanic(file, line, msg), 0))
+#define ASSERTMSGLINE(line, cond, msg) \
+    ((cond) || (OSPanic(__FILE__, line, msg), 0))
 
 // This is dumb but we dont have a Metrowerks way to do variadic macros in the macro to make this done in a not scrubby way.
-#define ASSERTMSG1LINE(file, line, cond, msg, arg1) \
-    ((cond) || (OSPanic(file, line, msg, arg1), 0))
+#define ASSERTMSG1LINE(line, cond, msg, arg1) \
+    ((cond) || (OSPanic(__FILE__, line, msg, arg1), 0))
     
-#define ASSERTMSG2LINE(file, line, cond, msg, arg1, arg2) \
-    ((cond) || (OSPanic(file, line, msg, arg1, arg2), 0))
+#define ASSERTMSG2LINE(line, cond, msg, arg1, arg2) \
+    ((cond) || (OSPanic(__FILE__, line, msg, arg1, arg2), 0))
 
 #else
-#define ASSERTLINE(file, line, cond) (void)0
-#define ASSERTMSGLINE(file, line, cond, msg) (void)0
-#define ASSERTMSG1LINE(file, line, cond, msg, arg1) (void)0
-#define ASSERTMSG2LINE(file, line, cond, msg, arg1, arg2) (void)0
+#define ASSERTLINE(line, cond) (void)0
+#define ASSERTMSGLINE(line, cond, msg) (void)0
+#define ASSERTMSG1LINE(line, cond, msg, arg1) (void)0
+#define ASSERTMSG2LINE(line, cond, msg, arg1, arg2) (void)0
 #endif
     
-#define ASSERT(cond) ASSERTLINE(__FILE__, __LINE__, cond)
+#define ASSERT(cond) ASSERTLINE(__LINE__, cond)
 
 #endif // _H_MACROS_

--- a/src/card/CARDRdwr.c
+++ b/src/card/CARDRdwr.c
@@ -39,8 +39,8 @@ static void BlockReadCallback(long chan, long result) {
 long __CARDRead(long chan, unsigned long addr, long length, void * dst, void (* callback)(long, long)) {
     struct CARDControl * card;
 
-    ASSERTLINE("CARDRdwr.c", 0x58, 0 < length && length % CARD_SEG_SIZE == 0);
-    ASSERTLINE("CARDRdwr.c", 0x59, 0 <= chan && chan < 2);
+    ASSERTLINE(0x58, 0 < length && length % CARD_SEG_SIZE == 0);
+    ASSERTLINE(0x59, 0 <= chan && chan < 2);
     card = &__CARDBlock[chan];
     if (card->attached == 0) {
         return -3;
@@ -82,8 +82,8 @@ static void BlockWriteCallback(long chan, long result) {
 long __CARDWrite(long chan, unsigned long addr, long length, void * dst, void (* callback)(long, long)) {
     struct CARDControl * card;
 
-    ASSERTLINE("CARDRdwr.c", 0x95, 0 < length && length % CARD_PAGE_SIZE == 0);
-    ASSERTLINE("CARDRdwr.c", 0x96, 0 <= chan && chan < 2);
+    ASSERTLINE(0x95, 0 < length && length % CARD_PAGE_SIZE == 0);
+    ASSERTLINE(0x96, 0 <= chan && chan < 2);
     card = &__CARDBlock[chan];
     if (card->attached == 0) {
         return -3;
@@ -96,6 +96,6 @@ long __CARDWrite(long chan, unsigned long addr, long length, void * dst, void (*
 }
 
 long CARDGetXferredBytes(long chan) {
-    ASSERTLINE("CARDRdwr.c", 0xB4, 0 <= chan && chan < 2);
+    ASSERTLINE(0xB4, 0 <= chan && chan < 2);
     return __CARDBlock[chan].xferred;
 }

--- a/src/card/CARDRead.c
+++ b/src/card/CARDRead.c
@@ -18,15 +18,15 @@ s32 __CARDSeek(CARDFileInfo *fileInfo, s32 length, s32 offset, CARDControl **pca
     s32 result;
     u16 *fat;
 
-    ASSERTLINE("CARDRead.c", 0x57, 0 <= fileInfo->chan && fileInfo->chan < 2);
-    ASSERTLINE("CARDRead.c", 0x58, 0 <= fileInfo->fileNo && fileInfo->fileNo < CARD_MAX_FILE);
+    ASSERTLINE(0x57, 0 <= fileInfo->chan && fileInfo->chan < 2);
+    ASSERTLINE(0x58, 0 <= fileInfo->fileNo && fileInfo->fileNo < CARD_MAX_FILE);
 
     result = __CARDGetControlBlock(fileInfo->chan, &card);
     if (result < 0)
         return result;
 
-    ASSERTLINE("CARDRead.c", 0x5F, CARDIsValidBlockNo(card, fileInfo->iBlock));
-    ASSERTLINE("CARDRead.c", 0x60, fileInfo->offset < card->cBlock * card->sectorSize);
+    ASSERTLINE(0x5F, CARDIsValidBlockNo(card, fileInfo->iBlock));
+    ASSERTLINE(0x60, fileInfo->offset < card->cBlock * card->sectorSize);
 
     if (!CARDIsValidBlockNo(card, fileInfo->iBlock) || card->cBlock * card->sectorSize <= fileInfo->offset)
         return __CARDPutControlBlock(card, CARD_RESULT_FATAL_ERROR);
@@ -34,7 +34,7 @@ s32 __CARDSeek(CARDFileInfo *fileInfo, s32 length, s32 offset, CARDControl **pca
     dir = __CARDGetDirBlock(card);
     ent = &dir[fileInfo->fileNo];
 
-    ASSERTLINE("CARDRead.c", 0x6A, ent->gameName[0] != 0xff);
+    ASSERTLINE(0x6A, ent->gameName[0] != 0xff);
 
     if (ent->length * card->sectorSize <= offset || ent->length * card->sectorSize < offset + length)
         return __CARDPutControlBlock(card, CARD_RESULT_LIMIT);
@@ -98,8 +98,8 @@ static void ReadCallback(s32 chan, s32 result) {
         goto error;
     }
 
-    ASSERTLINE("CARDRead.c", 0xBC, OFFSET(fileInfo->length, CARD_SEG_SIZE) == 0);
-    ASSERTLINE("CARDRead.c", 0xBD, OFFSET(fileInfo->offset, card->sectorSize) == 0);
+    ASSERTLINE(0xBC, OFFSET(fileInfo->length, CARD_SEG_SIZE) == 0);
+    ASSERTLINE(0xBD, OFFSET(fileInfo->offset, card->sectorSize) == 0);
 
     result = __CARDRead(chan, card->sectorSize * (u32)fileInfo->iBlock,
                         (fileInfo->length < card->sectorSize) ? fileInfo->length : card->sectorSize, card->buffer,
@@ -113,7 +113,7 @@ error:
     callback = card->apiCallback;
     card->apiCallback = NULL;
     __CARDPutControlBlock(card, result);
-    ASSERTLINE("CARDRead.c", 0xCE, callback);
+    ASSERTLINE(0xCE, callback);
     callback(chan, result);
 }
 
@@ -123,9 +123,9 @@ s32 CARDReadAsync(CARDFileInfo *fileInfo, void *buf, s32 length, s32 offset, CAR
     CARDDir *dir;
     CARDDir *ent;
 
-    ASSERTLINE("CARDRead.c", 0xF0, buf && OFFSET(buf, 32) == 0);
-    ASSERTLINE("CARDRead.c", 0xF1, OFFSET(offset, CARD_SEG_SIZE) == 0);
-    ASSERTLINE("CARDRead.c", 0xF2, 0 < length && OFFSET(length, CARD_SEG_SIZE) == 0);
+    ASSERTLINE(0xF0, buf && OFFSET(buf, 32) == 0);
+    ASSERTLINE(0xF1, OFFSET(offset, CARD_SEG_SIZE) == 0);
+    ASSERTLINE(0xF2, 0 < length && OFFSET(length, CARD_SEG_SIZE) == 0);
 
     if (OFFSET(offset, CARD_SEG_SIZE) != 0 || OFFSET(length, CARD_SEG_SIZE) != 0)
         return CARD_RESULT_FATAL_ERROR;
@@ -166,8 +166,8 @@ s32 CARDCancel(CARDFileInfo *fileInfo) {
     s32 result;
     CARDControl *card;
 
-    ASSERTLINE("CARDRead.c", 0x14D, 0 <= fileInfo->chan && fileInfo->chan < 2);
-    ASSERTLINE("CARDRead.c", 0x14E, 0 <= fileInfo->fileNo && fileInfo->fileNo < CARD_MAX_FILE);
+    ASSERTLINE(0x14D, 0 <= fileInfo->chan && fileInfo->chan < 2);
+    ASSERTLINE(0x14E, 0 <= fileInfo->fileNo && fileInfo->fileNo < CARD_MAX_FILE);
 
     intrEnabled = OSDisableInterrupts();
     

--- a/src/card/CARDRename.c
+++ b/src/card/CARDRename.c
@@ -16,9 +16,9 @@ s32 CARDRenameAsync(s32 chan, char *old, char *new, CARDCallback callback) {
     int newNo;
     int oldNo;
 
-    ASSERTLINE("CARDRename.c", 0x49, 0 <= chan && chan < 2);
-    ASSERTLINE("CARDRename.c", 0x4A, *old != 0xff && *new != 0xff);
-    ASSERTLINE("CARDRename.c", 0x4B, *old != 0x00 && *new != 0x00);
+    ASSERTLINE(0x49, 0 <= chan && chan < 2);
+    ASSERTLINE(0x4A, *old != 0xff && *new != 0xff);
+    ASSERTLINE(0x4B, *old != 0x00 && *new != 0x00);
 
     if (old[0] == 0xFF || new[0] == 0xFF || old[0] == 0 || new[0] == 0)
         return CARD_RESULT_FATAL_ERROR;

--- a/src/card/CARDStat.c
+++ b/src/card/CARDStat.c
@@ -108,8 +108,8 @@ s32 CARDGetStatus(s32 chan, s32 fileNo, CARDStat *stat) {
     CARDDir *ent;
     s32 result;
 
-    ASSERTLINE("CARDStat.c", 0x97, 0 <= chan && chan < 2);
-    ASSERTLINE("CARDStat.c", 0x98, 0 <= fileNo && fileNo < CARD_MAX_FILE);
+    ASSERTLINE(0x97, 0 <= chan && chan < 2);
+    ASSERTLINE(0x98, 0 <= fileNo && fileNo < CARD_MAX_FILE);
 
     if (fileNo < 0 || CARD_MAX_FILE <= fileNo)
         return CARD_RESULT_FATAL_ERROR;
@@ -149,8 +149,8 @@ s32 CARDSetStatusAsync(s32 chan, s32 fileNo, CARDStat *stat, CARDCallback callba
     CARDDir *ent;
     s32 result;
 
-    ASSERTLINE("CARDStat.c", 0xD5, 0 <= fileNo && fileNo < CARD_MAX_FILE);
-    ASSERTLINE("CARDStat.c", 0xD6, 0 <= chan && chan < 2);
+    ASSERTLINE(0xD5, 0 <= fileNo && fileNo < CARD_MAX_FILE);
+    ASSERTLINE(0xD6, 0 <= chan && chan < 2);
 
     if (fileNo < 0 || CARD_MAX_FILE <= fileNo)
         return CARD_RESULT_FATAL_ERROR;

--- a/src/card/CARDStatEx.c
+++ b/src/card/CARDStatEx.c
@@ -4,8 +4,8 @@
 #include "__card.h"
 
 long __CARDGetStatusEx(long chan, long fileNo, struct CARDDir * dirent) {
-    ASSERTLINE("CARDStatEx.c", 0x45, 0 <= chan && chan < 2);
-    ASSERTLINE("CARDStatEx.c", 0x46, 0 <= fileNo && fileNo < CARD_MAX_FILE);
+    ASSERTLINE(0x45, 0 <= chan && chan < 2);
+    ASSERTLINE(0x46, 0 <= fileNo && fileNo < CARD_MAX_FILE);
 
     if ((fileNo < 0) || (fileNo >= CARD_MAX_FILE)) {
         return -0x80;
@@ -42,9 +42,9 @@ long __CARDSetStatusExAsync(long chan, long fileNo, struct CARDDir * dirent, voi
     unsigned char * p;
     long i;
 
-    ASSERTLINE("CARDStatEx.c", 0x81, 0 <= fileNo && fileNo < CARD_MAX_FILE);
-    ASSERTLINE("CARDStatEx.c", 0x82, 0 <= chan && chan < 2);
-    ASSERTLINE("CARDStatEx.c", 0x83, *dirent->fileName != 0xff && *dirent->fileName != 0x00);
+    ASSERTLINE(0x81, 0 <= fileNo && fileNo < CARD_MAX_FILE);
+    ASSERTLINE(0x82, 0 <= chan && chan < 2);
+    ASSERTLINE(0x83, *dirent->fileName != 0xff && *dirent->fileName != 0x00);
 
     if ((fileNo < 0) || (fileNo >= CARD_MAX_FILE) || ((u8) dirent->fileName[0] == 0xFF) || ((u8) dirent->fileName[0] == 0)) {
         return -0x80;

--- a/src/card/CARDUnlock.c
+++ b/src/card/CARDUnlock.c
@@ -102,7 +102,7 @@ static s32 ReadArrayUnlock(s32 chan, u32 data, void *rbuf, s32 rlen, s32 mode) {
     BOOL err;
     u8 cmd[5];
 
-    ASSERTLINE("CARDUnlock.c", 0xD1, 0 <= chan && chan < 2);
+    ASSERTLINE(0xD1, 0 <= chan && chan < 2);
 
     card = &__CARDBlock[chan];
     if (!EXISelect(chan, 0, 4))
@@ -311,7 +311,7 @@ static void InitCallback(void *_task)
             break;
     }
 
-    ASSERTLINE("CARDUnlock.c", 0x1E3, 0 <= chan && chan < 2);
+    ASSERTLINE(0x1E3, 0 <= chan && chan < 2);
     
     param = (CARDDecParam *)card->workArea;
 
@@ -352,7 +352,7 @@ static void DoneCallback(void *_task)
             break;
     }
 
-    ASSERTLINE("CARDUnlock.c", 0x214, 0 <= chan && chan < 2);
+    ASSERTLINE(0x214, 0 <= chan && chan < 2);
 
     param = (CARDDecParam *)card->workArea;
     input = (u8 *)((u8 *)param + sizeof(CARDDecParam));

--- a/src/card/CARDWrite.c
+++ b/src/card/CARDWrite.c
@@ -51,7 +51,7 @@ after:;
         callback = card->apiCallback;
         card->apiCallback = NULL;
         __CARDPutControlBlock(card, result);
-        ASSERTLINE("CARDWrite.c", 0x7D, callback);
+        ASSERTLINE(0x7D, callback);
         callback(chan, result);
     }
 }
@@ -64,7 +64,7 @@ static void EraseCallback(long chan, long result) {
     card = &__CARDBlock[chan];
     if (result >= 0) {
         fileInfo = card->fileInfo;
-        ASSERTLINE("CARDWrite.c", 0x98, OFFSET(fileInfo->offset, card->sectorSize) == 0);
+        ASSERTLINE(0x98, OFFSET(fileInfo->offset, card->sectorSize) == 0);
         result = __CARDWrite(chan, card->sectorSize * fileInfo->iBlock, card->sectorSize, card->buffer, WriteCallback);
         if (result < 0) {
             goto after;
@@ -74,7 +74,7 @@ after:;
         callback = card->apiCallback;
         card->apiCallback = NULL;
         __CARDPutControlBlock(card, result);
-        ASSERTLINE("CARDWrite.c", 0xA6, callback);
+        ASSERTLINE(0xA6, callback);
         callback(chan, result);
     }
 }
@@ -85,14 +85,14 @@ long CARDWriteAsync(struct CARDFileInfo * fileInfo, void * buf, long length, lon
     struct CARDDir * dir;
     struct CARDDir * ent;
 
-    ASSERTLINE("CARDWrite.c", 0xC9, buf && ((u32) buf % 32) == 0);
-    ASSERTLINE("CARDWrite.c", 0xCA, 0 < length);
+    ASSERTLINE(0xC9, buf && ((u32) buf % 32) == 0);
+    ASSERTLINE(0xCA, 0 < length);
     result = __CARDSeek(fileInfo, length, offset, &card);
     if (result < 0) {
         return result;
     }
-    ASSERTLINE("CARDWrite.c", 0xD0, OFFSET(offset, card->sectorSize) == 0);
-    ASSERTLINE("CARDWrite.c", 0xD1, OFFSET(length, card->sectorSize) == 0);
+    ASSERTLINE(0xD0, OFFSET(offset, card->sectorSize) == 0);
+    ASSERTLINE(0xD1, OFFSET(length, card->sectorSize) == 0);
 
     if (OFFSET(offset, card->sectorSize) != 0 || OFFSET(length, card->sectorSize) != 0)
         return __CARDPutControlBlock(card, -0x80);

--- a/src/os/OS.c
+++ b/src/os/OS.c
@@ -139,7 +139,7 @@ void OSInit() {
         __OSInitSram();
         __OSThreadInit();
         __OSInitAudioSystem();
-        ASSERTLINE("OS.c", 0x252, BootInfo); // oh sure, assert NOW, you've already dereferenced it a bunch of times.
+        ASSERTLINE(0x252, BootInfo); // oh sure, assert NOW, you've already dereferenced it a bunch of times.
         if ((BootInfo->consoleType & OS_CONSOLE_DEVELOPMENT) != 0) {
             BootInfo->consoleType = OS_CONSOLE_DEVHW1;
         } else {
@@ -229,7 +229,7 @@ static void OSExceptionInit(void) {
     u8* handlerStart;
     u32 handlerSize;
     
-    ASSERTMSGLINE("OS.c", 0x2F1, ((u32)&__OSEVEnd - (u32)&__OSEVStart) <= 0x100, "OSExceptionInit(): too big exception vector code.");
+    ASSERTMSGLINE(0x2F1, ((u32)&__OSEVEnd - (u32)&__OSEVStart) <= 0x100, "OSExceptionInit(): too big exception vector code.");
       
     // Install the first level exception vector.
     opCodeAddr = (u32*)__OSEVSetNumber;
@@ -327,7 +327,7 @@ entry __OSDBJUMPEND
 __OSExceptionHandler __OSSetExceptionHandler(__OSException exception, __OSExceptionHandler handler) {
     __OSExceptionHandler oldHandler;
     
-    ASSERTMSGLINE("OS.c", 0x37F, exception < __OS_EXCEPTION_MAX, "__OSSetExceptionHandler(): unknown exception."); 
+    ASSERTMSGLINE(0x37F, exception < __OS_EXCEPTION_MAX, "__OSSetExceptionHandler(): unknown exception."); 
     
     oldHandler = OSExceptionTable[exception];
     OSExceptionTable[exception] = handler;
@@ -335,7 +335,7 @@ __OSExceptionHandler __OSSetExceptionHandler(__OSException exception, __OSExcept
 }
 
 __OSExceptionHandler __OSGetExceptionHandler(__OSException exception) {
-    ASSERTMSGLINE("OS.c", 0x396, exception < __OS_EXCEPTION_MAX, "__OSGetExceptionHandler(): unknown exception.");
+    ASSERTMSGLINE(0x396, exception < __OS_EXCEPTION_MAX, "__OSGetExceptionHandler(): unknown exception.");
     return OSExceptionTable[exception];
 }
 

--- a/src/os/OSAddress.c
+++ b/src/os/OSAddress.c
@@ -10,31 +10,31 @@
 #undef OSUncachedToCached
 
 void * OSPhysicalToCached(unsigned long paddr) {
-    ASSERTMSGLINE("OSAddress.c", 0x2C, paddr < 0x10000000U, "OSPhysicalToCached(): illegal address.");
+    ASSERTMSGLINE(0x2C, paddr < 0x10000000U, "OSPhysicalToCached(): illegal address.");
     return (void*)(paddr + 0x80000000);
 }
 
 void * OSPhysicalToUncached(unsigned long paddr) {
-    ASSERTMSGLINE("OSAddress.c", 0x3B, paddr < 0x10000000U, "OSPhysicalToUncached(): illegal address.");
+    ASSERTMSGLINE(0x3B, paddr < 0x10000000U, "OSPhysicalToUncached(): illegal address.");
     return (void*)(paddr - 0x40000000);
 }
 
 unsigned long OSCachedToPhysical(void * caddr) {
-    ASSERTMSGLINE("OSAddress.c", 0x4A, 0x80000000U <= (u32)caddr && (u32)caddr < 0x90000000U, "OSCachedToPhysical(): illegal address.");
+    ASSERTMSGLINE(0x4A, 0x80000000U <= (u32)caddr && (u32)caddr < 0x90000000U, "OSCachedToPhysical(): illegal address.");
     return (u32)caddr + 0x80000000;
 }
 
 unsigned long OSUncachedToPhysical(void * ucaddr) {
-    ASSERTMSGLINE("OSAddress.c", 0x59, 0xC0000000U <= (u32)ucaddr && (u32)ucaddr < 0xD0000000U, "OSUncachedToPhysical(): illegal address.");
+    ASSERTMSGLINE(0x59, 0xC0000000U <= (u32)ucaddr && (u32)ucaddr < 0xD0000000U, "OSUncachedToPhysical(): illegal address.");
     return (u32)ucaddr + 0x40000000;
 }
 
 void * OSCachedToUncached(void * caddr) {
-    ASSERTMSGLINE("OSAddress.c", 0x68, 0x80000000U <= (u32)caddr && (u32)caddr < 0x90000000U, "OSCachedToUncached(): illegal address.");
+    ASSERTMSGLINE(0x68, 0x80000000U <= (u32)caddr && (u32)caddr < 0x90000000U, "OSCachedToUncached(): illegal address.");
     return (void*)((u32)caddr + 0x40000000);
 }
 
 void * OSUncachedToCached(void * ucaddr) {
-    ASSERTMSGLINE("OSAddress.c", 0x77, 0xC0000000U <= (u32)ucaddr && (u32)ucaddr < 0xD0000000U, "OSUncachedToCached(): illegal address.");
+    ASSERTMSGLINE(0x77, 0xC0000000U <= (u32)ucaddr && (u32)ucaddr < 0xD0000000U, "OSUncachedToCached(): illegal address.");
     return (void*)((u32)ucaddr - 0x40000000);
 }

--- a/src/os/OSAlarm.c
+++ b/src/os/OSAlarm.c
@@ -17,19 +17,19 @@ static void InsertAlarm(OSAlarm* alarm, OSTime fire, OSAlarmHandler handler);
 static void DecrementerExceptionCallback(register __OSException exception, register OSContext* context);
 static void DecrementerExceptionHandler(__OSException exception, OSContext* context);
 
-#define ASSERTREPORT(file, line, cond) \
+#define ASSERTREPORT(line, cond) \
     if (!(cond)) { OSReport("OSCheckAlarmQueue: Failed " #cond " in %d", line); return 0; }
 
 int OSCheckAlarmQueue() {
     struct OSAlarm * alarm;
 
-    ASSERTREPORT("OSAlarm.c", 0x70, AlarmQueue.head == NULL && AlarmQueue.tail == NULL || AlarmQueue.head != NULL && AlarmQueue.tail != NULL);
-    ASSERTREPORT("OSAlarm.c", 0x71, AlarmQueue.head == NULL || AlarmQueue.head->prev == NULL);
-    ASSERTREPORT("OSAlarm.c", 0x72, AlarmQueue.tail == NULL || AlarmQueue.tail->next == NULL);
+    ASSERTREPORT(0x70, AlarmQueue.head == NULL && AlarmQueue.tail == NULL || AlarmQueue.head != NULL && AlarmQueue.tail != NULL);
+    ASSERTREPORT(0x71, AlarmQueue.head == NULL || AlarmQueue.head->prev == NULL);
+    ASSERTREPORT(0x72, AlarmQueue.tail == NULL || AlarmQueue.tail->next == NULL);
 
     for(alarm = AlarmQueue.head; alarm; alarm = alarm->next) {
-        ASSERTREPORT("OSAlarm.c", 0x75, alarm->next == NULL || alarm->next->prev == alarm);
-        ASSERTREPORT("OSAlarm.c", 0x76, alarm->next != NULL || AlarmQueue.tail == alarm);
+        ASSERTREPORT(0x75, alarm->next == NULL || alarm->next->prev == alarm);
+        ASSERTREPORT(0x76, alarm->next != NULL || AlarmQueue.tail == alarm);
     }
     return 1;
 }
@@ -70,7 +70,7 @@ static void InsertAlarm(OSAlarm* alarm, OSTime fire, OSAlarmHandler handler) {
         }
     }
     
-    ASSERTLINE("OSAlarm.c", 0xD6, alarm->handler == 0);
+    ASSERTLINE(0xD6, alarm->handler == 0);
     
     alarm->handler = handler;
     alarm->fire = fire;
@@ -95,7 +95,7 @@ static void InsertAlarm(OSAlarm* alarm, OSTime fire, OSAlarmHandler handler) {
         return;
     }
 
-    ASSERTLINE("OSAlarm.c", 0xF3, next == 0);
+    ASSERTLINE(0xF3, next == 0);
 
     alarm->next = 0;
     prev = AlarmQueue.tail;
@@ -112,35 +112,35 @@ static void InsertAlarm(OSAlarm* alarm, OSTime fire, OSAlarmHandler handler) {
 
 void OSSetAlarm(OSAlarm* alarm, OSTime tick, OSAlarmHandler handler) {
     BOOL enabled;
-    ASSERTMSGLINE("OSAlarm.c", 0x114, tick > 0, "OSSetAlarm(): tick was less than zero.");
-    ASSERTMSGLINE("OSAlarm.c", 0x115, handler, "OSSetAlarm(): null handler was specified.");
+    ASSERTMSGLINE(0x114, tick > 0, "OSSetAlarm(): tick was less than zero.");
+    ASSERTMSGLINE(0x115, handler, "OSSetAlarm(): null handler was specified.");
     enabled = OSDisableInterrupts();
     alarm->period = 0;
     InsertAlarm(alarm, OSGetTime() + tick, handler);
-    ASSERTLINE("OSAlarm.c", 0x11C, OSCheckAlarmQueue());
+    ASSERTLINE(0x11C, OSCheckAlarmQueue());
     OSRestoreInterrupts(enabled);
 }
 
 void OSSetAbsAlarm(struct OSAlarm * alarm, long long time, void (* handler)(struct OSAlarm *, struct OSContext *)) {
     int enabled;
 
-    ASSERTMSGLINE("OSAlarm.c", 0x130, handler, "OSSetAbsAlarm(): null handler was specified.");
+    ASSERTMSGLINE(0x130, handler, "OSSetAbsAlarm(): null handler was specified.");
     enabled = OSDisableInterrupts();
     alarm->period = 0;
     InsertAlarm(alarm, time, handler);
-    ASSERTLINE("OSAlarm.c", 0x137, OSCheckAlarmQueue());
+    ASSERTLINE(0x137, OSCheckAlarmQueue());
     OSRestoreInterrupts(enabled);
 }
 
 void OSSetPeriodicAlarm(OSAlarm* alarm, OSTime start, OSTime period, OSAlarmHandler handler) {
     BOOL enabled;
-    ASSERTMSGLINE("OSAlarm.c", 0x14D, period > 0, "OSSetPeriodicAlarm(): period was less than zero.");
-    ASSERTMSGLINE("OSAlarm.c", 0x14E, handler, "OSSetPeriodicAlarm(): null handler was specified.");
+    ASSERTMSGLINE(0x14D, period > 0, "OSSetPeriodicAlarm(): period was less than zero.");
+    ASSERTMSGLINE(0x14E, handler, "OSSetPeriodicAlarm(): null handler was specified.");
     enabled = OSDisableInterrupts();
     alarm->period = period;
     alarm->start = start;
     InsertAlarm(alarm, 0, handler);
-    ASSERTLINE("OSAlarm.c", 0x156, OSCheckAlarmQueue());
+    ASSERTLINE(0x156, OSCheckAlarmQueue());
     OSRestoreInterrupts(enabled);
 }
 
@@ -170,7 +170,7 @@ void OSCancelAlarm(OSAlarm* alarm) {
         }
     }
     alarm->handler = 0;
-    ASSERTLINE("OSAlarm.c", 0x189, OSCheckAlarmQueue());
+    ASSERTLINE(0x189, OSCheckAlarmQueue());
     OSRestoreInterrupts(enabled);
 }
 
@@ -199,12 +199,12 @@ static void DecrementerExceptionCallback(register __OSException exception,
     } else {
         next->prev = 0;
     }
-    ASSERTLINE("OSAlarm.c", 0x1C2, OSCheckAlarmQueue());
+    ASSERTLINE(0x1C2, OSCheckAlarmQueue());
     handler = alarm->handler;
     alarm->handler = 0;
     if (0 < alarm->period) {
         InsertAlarm(alarm, 0, handler);
-        ASSERTLINE("OSAlarm.c", 0x1CC, OSCheckAlarmQueue());
+        ASSERTLINE(0x1CC, OSCheckAlarmQueue());
     }
 
     if (AlarmQueue.head) {

--- a/src/os/OSAlloc.c
+++ b/src/os/OSAlloc.c
@@ -120,10 +120,10 @@ void * OSAllocFromHeap(int heap, unsigned long size) {
     long requested;
 
     requested = size;
-    ASSERTMSGLINE("OSAlloc.c", 0x14D, HeapArray, "OSAllocFromHeap(): heap is not initialized.");
-    ASSERTMSGLINE("OSAlloc.c", 0x14E, (signed long)size > 0, "OSAllocFromHeap(): invalid size.");
-    ASSERTMSGLINE("OSAlloc.c", 0x14F, heap >= 0 && heap < NumHeaps, "OSAllocFromHeap(): invalid heap handle.");
-    ASSERTMSGLINE("OSAlloc.c", 0x150, HeapArray[heap].size >= 0, "OSAllocFromHeap(): invalid heap handle.");
+    ASSERTMSGLINE(0x14D, HeapArray, "OSAllocFromHeap(): heap is not initialized.");
+    ASSERTMSGLINE(0x14E, (signed long)size > 0, "OSAllocFromHeap(): invalid size.");
+    ASSERTMSGLINE(0x14F, heap >= 0 && heap < NumHeaps, "OSAllocFromHeap(): invalid heap handle.");
+    ASSERTMSGLINE(0x150, HeapArray[heap].size >= 0, "OSAllocFromHeap(): invalid heap handle.");
 
     hd = &HeapArray[heap];
     size += 0x20;
@@ -141,8 +141,8 @@ void * OSAllocFromHeap(int heap, unsigned long size) {
 #endif
         return NULL;
     }
-    ASSERTMSGLINE("OSAlloc.c", 0x168, !((s32)cell & 0x1F), "OSAllocFromHeap(): heap is broken.");
-    ASSERTMSGLINE("OSAlloc.c", 0x169, cell->hd == NULL, "OSAllocFromHeap(): heap is broken.");
+    ASSERTMSGLINE(0x168, !((s32)cell & 0x1F), "OSAllocFromHeap(): heap is broken.");
+    ASSERTMSGLINE(0x169, cell->hd == NULL, "OSAllocFromHeap(): heap is broken.");
 
     leftoverSize = cell->size - size;
     if (leftoverSize < 0x40U) {
@@ -162,7 +162,7 @@ void * OSAllocFromHeap(int heap, unsigned long size) {
         if (newCell->prev != NULL) {
             newCell->prev->next = newCell; 
         } else {
-            ASSERTMSGLINE("OSAlloc.c", 0x186, hd->free == cell, "OSAllocFromHeap(): heap is broken.");
+            ASSERTMSGLINE(0x186, hd->free == cell, "OSAllocFromHeap(): heap is broken.");
             hd->free = newCell;
         }
     }
@@ -190,9 +190,9 @@ void * OSAllocFixed(void * rstart, void * rend) {
     start = (void*)((*(u32*)rstart) & ~((32)-1));
     end = (void*)((*(u32*)rend + 0x1FU) & ~((32)-1));
 
-    ASSERTMSGLINE("OSAlloc.c", 0x1B0, HeapArray, "OSAllocFixed(): heap is not initialized.");
-    ASSERTMSGLINE("OSAlloc.c", 0x1B1, (u32)start < (u32)end, "OSAllocFixed(): invalid range.");
-    ASSERTMSGLINE("OSAlloc.c", 0x1B3, ((u32) ArenaStart <= (u32) start) && ((u32) end <= (u32) ArenaEnd), "OSAllocFixed(): invalid range.");
+    ASSERTMSGLINE(0x1B0, HeapArray, "OSAllocFixed(): heap is not initialized.");
+    ASSERTMSGLINE(0x1B1, (u32)start < (u32)end, "OSAllocFixed(): invalid range.");
+    ASSERTMSGLINE(0x1B3, ((u32) ArenaStart <= (u32) start) && ((u32) end <= (u32) ArenaEnd), "OSAllocFixed(): invalid range.");
 
     for(i = 0; i < NumHeaps; i++) {
         hd = &HeapArray[i];
@@ -228,7 +228,7 @@ void * OSAllocFixed(void * rstart, void * rend) {
                             if (cell < start) {
                                 start = cell;
                             }
-                            ASSERTLINE("OSAlloc.c", 0x1F3, MINOBJSIZE <= (char*) cellEnd - (char*) end);
+                            ASSERTLINE(0x1F3, MINOBJSIZE <= (char*) cellEnd - (char*) end);
                             newCell = (struct Cell*)end;
 
                             newCell->size = (s32) ((char*)cellEnd - (char*)end);
@@ -252,11 +252,11 @@ void * OSAllocFixed(void * rstart, void * rend) {
                             if (end < cellEnd) {
                                 end = cellEnd;
                             }
-                            ASSERTLINE("OSAlloc.c", 0x20C, MINOBJSIZE <= (char*) start - (char*) cell);
+                            ASSERTLINE(0x20C, MINOBJSIZE <= (char*) start - (char*) cell);
                             hd->size -= ((char*)cellEnd - (char*)start);
                             cell->size = ((char*)start - (char*)cell);
                         } else {
-                            ASSERTLINE("OSAlloc.c", 0x213, MINOBJSIZE <= (char*) cellEnd - (char*) end);
+                            ASSERTLINE(0x213, MINOBJSIZE <= (char*) cellEnd - (char*) end);
                             newCell = (struct Cell*)end;
                             newCell->size = ((char*)cellEnd - (char*)end);
 #ifdef ENABLE_HEAPDESC
@@ -275,12 +275,12 @@ void * OSAllocFixed(void * rstart, void * rend) {
                     }
                 }
             }
-            ASSERTLINE("OSAlloc.c", 0x222, 0 <= hd->size);
+            ASSERTLINE(0x222, 0 <= hd->size);
         }
     }
-    ASSERTLINE("OSAlloc.c", 0x225, OFFSET(start, ALIGNMENT) == 0);
-    ASSERTLINE("OSAlloc.c", 0x226, OFFSET(end, ALIGNMENT) == 0);
-    ASSERTLINE("OSAlloc.c", 0x227, start < end);
+    ASSERTLINE(0x225, OFFSET(start, ALIGNMENT) == 0);
+    ASSERTLINE(0x226, OFFSET(end, ALIGNMENT) == 0);
+    ASSERTLINE(0x227, start < end);
     *(u32*)rstart = (u32)start;
     *(u32*)rend = (u32)end;
     return (void*)*(u32*)rstart;
@@ -290,14 +290,14 @@ void OSFreeToHeap(int heap, void * ptr) {
     struct HeapDesc * hd;
     struct Cell * cell;
 
-    ASSERTMSGLINE("OSAlloc.c", 0x23D, HeapArray, "OSFreeToHeap(): heap is not initialized.");
-    ASSERTMSGLINE("OSAlloc.c", 0x23F, ((u32)ArenaStart+0x20) <= (u32)ptr && (u32)ptr < (u32)ArenaEnd, "OSFreeToHeap(): invalid pointer.");
-    ASSERTMSGLINE("OSAlloc.c", 0x240, OFFSET(ptr, ALIGNMENT) == 0, "OSFreeToHeap(): invalid pointer.");
-    ASSERTMSGLINE("OSAlloc.c", 0x241, HeapArray[heap].size >= 0, "OSFreeToHeap(): invalid heap handle.");
+    ASSERTMSGLINE(0x23D, HeapArray, "OSFreeToHeap(): heap is not initialized.");
+    ASSERTMSGLINE(0x23F, ((u32)ArenaStart+0x20) <= (u32)ptr && (u32)ptr < (u32)ArenaEnd, "OSFreeToHeap(): invalid pointer.");
+    ASSERTMSGLINE(0x240, OFFSET(ptr, ALIGNMENT) == 0, "OSFreeToHeap(): invalid pointer.");
+    ASSERTMSGLINE(0x241, HeapArray[heap].size >= 0, "OSFreeToHeap(): invalid heap handle.");
     cell = (void*)((u32)ptr-0x20);
     hd = &HeapArray[heap];
-    ASSERTMSGLINE("OSAlloc.c", 0x246, cell->hd == hd, "OSFreeToHeap(): invalid pointer.");
-    ASSERTMSGLINE("OSAlloc.c", 0x247, DLLookup(hd->allocated, cell), "OSFreeToHeap(): invalid pointer.");
+    ASSERTMSGLINE(0x246, cell->hd == hd, "OSFreeToHeap(): invalid pointer.");
+    ASSERTMSGLINE(0x247, DLLookup(hd->allocated, cell), "OSFreeToHeap(): invalid pointer.");
 #ifdef ENABLE_HEAPDESC
     cell->hd = 0;
     hd->headerBytes -= 0x20;
@@ -311,9 +311,9 @@ void OSFreeToHeap(int heap, void * ptr) {
 int OSSetCurrentHeap(int heap) {
     int prev;
 
-    ASSERTMSGLINE("OSAlloc.c", 0x267, HeapArray, "OSSetCurrentHeap(): heap is not initialized.");
-    ASSERTMSGLINE("OSAlloc.c", 0x268, (heap >= 0) && (heap < NumHeaps), "OSSetCurrentHeap(): invalid heap handle.");
-    ASSERTMSGLINE("OSAlloc.c", 0x269, HeapArray[heap].size >= 0, "OSSetCurrentHeap(): invalid heap handle.");
+    ASSERTMSGLINE(0x267, HeapArray, "OSSetCurrentHeap(): heap is not initialized.");
+    ASSERTMSGLINE(0x268, (heap >= 0) && (heap < NumHeaps), "OSSetCurrentHeap(): invalid heap handle.");
+    ASSERTMSGLINE(0x269, HeapArray[heap].size >= 0, "OSSetCurrentHeap(): invalid heap handle.");
     prev = __OSCurrHeap;
     __OSCurrHeap = heap;
     return prev;
@@ -324,9 +324,9 @@ void * OSInitAlloc(void * arenaStart, void * arenaEnd, int maxHeaps) {
     int i;
     struct HeapDesc * hd;
 
-    ASSERTMSGLINE("OSAlloc.c", 0x283, maxHeaps > 0, "OSInitAlloc(): invalid number of heaps.");
-    ASSERTMSGLINE("OSAlloc.c", 0x285, (u32)arenaStart < (u32)arenaEnd, "OSInitAlloc(): invalid range.");
-    ASSERTMSGLINE("OSAlloc.c", 0x288, maxHeaps <= (((u32)arenaEnd - (u32)arenaStart) / 24U), "OSInitAlloc(): too small range.");
+    ASSERTMSGLINE(0x283, maxHeaps > 0, "OSInitAlloc(): invalid number of heaps.");
+    ASSERTMSGLINE(0x285, (u32)arenaStart < (u32)arenaEnd, "OSInitAlloc(): invalid range.");
+    ASSERTMSGLINE(0x288, maxHeaps <= (((u32)arenaEnd - (u32)arenaStart) / 24U), "OSInitAlloc(): too small range.");
     arraySize = maxHeaps * sizeof(struct HeapDesc);
     HeapArray = arenaStart;
     NumHeaps = maxHeaps;
@@ -344,7 +344,7 @@ void * OSInitAlloc(void * arenaStart, void * arenaEnd, int maxHeaps) {
     arenaStart = (void*) (((u32)arenaStart + 0x1F) & 0xFFFFFFE0);
     ArenaStart = arenaStart;
     ArenaEnd = (void*) ((u32)arenaEnd & 0xFFFFFFE0);
-    ASSERTMSGLINE("OSAlloc.c", 0x2A4, ((u32)ArenaEnd - (u32)ArenaStart) >= 0x40U, "OSInitAlloc(): too small range.");
+    ASSERTMSGLINE(0x2A4, ((u32)ArenaEnd - (u32)ArenaStart) >= 0x40U, "OSInitAlloc(): too small range.");
     return arenaStart;
 }
 
@@ -353,21 +353,21 @@ int OSCreateHeap(void * start, void * end) {
     struct HeapDesc * hd;
     struct Cell * cell;
 
-    ASSERTMSGLINE("OSAlloc.c", 0x2BD, HeapArray, "OSCreateHeap(): heap is not initialized.");
-    ASSERTMSGLINE("OSAlloc.c", 0x2BE, (u32)start < (u32)end, "OSCreateHeap(): invalid range.");
+    ASSERTMSGLINE(0x2BD, HeapArray, "OSCreateHeap(): heap is not initialized.");
+    ASSERTMSGLINE(0x2BE, (u32)start < (u32)end, "OSCreateHeap(): invalid range.");
 
     start = (void*)(((u32)start + 0x1FU) & ~((32)-1));
     end = (void*)(((u32)end) & ~((32)-1));
 
-    ASSERTMSGLINE("OSAlloc.c", 0x2C1, (u32)start < (u32)end, "OSCreateHeap(): invalid range.");
-    ASSERTMSGLINE("OSAlloc.c", 0x2C3, (u32)ArenaStart <= (u32)start && (u32)end <= (u32)ArenaEnd, "OSCreateHeap(): invalid range.");
-    ASSERTMSGLINE("OSAlloc.c", 0x2C5, ((u32)end - (u32)start) >= 0x40U, "OSCreateHeap(): too small range.");
+    ASSERTMSGLINE(0x2C1, (u32)start < (u32)end, "OSCreateHeap(): invalid range.");
+    ASSERTMSGLINE(0x2C3, (u32)ArenaStart <= (u32)start && (u32)end <= (u32)ArenaEnd, "OSCreateHeap(): invalid range.");
+    ASSERTMSGLINE(0x2C5, ((u32)end - (u32)start) >= 0x40U, "OSCreateHeap(): too small range.");
 
 #if DEBUG
     for(heap = 0; heap < NumHeaps; heap++) {
         if (HeapArray[heap].size >= 0) {
-            ASSERTMSGLINE("OSAlloc.c", 0x2CF, !DLOverlap(HeapArray[heap].free, start, end), "OSCreateHeap(): invalid range.");
-            ASSERTMSGLINE("OSAlloc.c", 0x2D1, !DLOverlap(HeapArray[heap].allocated, start, end), "OSCreateHeap(): invalid range.");
+            ASSERTMSGLINE(0x2CF, !DLOverlap(HeapArray[heap].free, start, end), "OSCreateHeap(): invalid range.");
+            ASSERTMSGLINE(0x2D1, !DLOverlap(HeapArray[heap].allocated, start, end), "OSCreateHeap(): invalid range.");
         }
     }
 #endif
@@ -401,9 +401,9 @@ void OSDestroyHeap(int heap) {
     struct HeapDesc * hd;
     long size;
 
-    ASSERTMSGLINE("OSAlloc.c", 0x30A, HeapArray, "OSDestroyHeap(): heap is not initialized.");
-    ASSERTMSGLINE("OSAlloc.c", 0x30B, (heap >= 0) && (heap < NumHeaps), "OSDestroyHeap(): invalid heap handle.");
-    ASSERTMSGLINE("OSAlloc.c", 0x30C, HeapArray[heap].size >= 0, "OSDestroyHeap(): invalid heap handle.");
+    ASSERTMSGLINE(0x30A, HeapArray, "OSDestroyHeap(): heap is not initialized.");
+    ASSERTMSGLINE(0x30B, (heap >= 0) && (heap < NumHeaps), "OSDestroyHeap(): invalid heap handle.");
+    ASSERTMSGLINE(0x30C, HeapArray[heap].size >= 0, "OSDestroyHeap(): invalid heap handle.");
 
     hd = &HeapArray[heap];
 #if DEBUG
@@ -428,25 +428,25 @@ void OSAddToHeap(int heap, void * start, void * end) {
     struct Cell * cell;
     int i;
 
-    ASSERTMSGLINE("OSAlloc.c", 0x339, HeapArray, "OSAddToHeap(): heap is not initialized.");
-    ASSERTMSGLINE("OSAlloc.c", 0x33A, (heap >= 0) && (heap < NumHeaps), "OSAddToHeap(): invalid heap handle.");
-    ASSERTMSGLINE("OSAlloc.c", 0x33B, HeapArray[heap].size >= 0, "OSAddToHeap(): invalid heap handle.");
+    ASSERTMSGLINE(0x339, HeapArray, "OSAddToHeap(): heap is not initialized.");
+    ASSERTMSGLINE(0x33A, (heap >= 0) && (heap < NumHeaps), "OSAddToHeap(): invalid heap handle.");
+    ASSERTMSGLINE(0x33B, HeapArray[heap].size >= 0, "OSAddToHeap(): invalid heap handle.");
 
     hd = &HeapArray[heap];
 
-    ASSERTMSGLINE("OSAlloc.c", 0x33F, (u32)start < (u32)end, "OSAddToHeap(): invalid range.");
+    ASSERTMSGLINE(0x33F, (u32)start < (u32)end, "OSAddToHeap(): invalid range.");
 
     start = (void*)(((u32)start + 0x1F) & ~((32)-1));
     end = (void*)(((u32)end) & ~((32)-1));
 
-    ASSERTMSGLINE("OSAlloc.c", 0x343, ((u32)end - (u32)start) >= 0x40U, "OSAddToHeap(): too small range.");
-    ASSERTMSGLINE("OSAlloc.c", 0x345, (u32)ArenaStart <= (u32)start && (u32)end <= (u32)ArenaEnd, "OSAddToHeap(): invalid range.");
+    ASSERTMSGLINE(0x343, ((u32)end - (u32)start) >= 0x40U, "OSAddToHeap(): too small range.");
+    ASSERTMSGLINE(0x345, (u32)ArenaStart <= (u32)start && (u32)end <= (u32)ArenaEnd, "OSAddToHeap(): invalid range.");
 
 #if DEBUG
     for(i = 0; i < NumHeaps; i++) {
         if (HeapArray[i].size >= 0) {
-            ASSERTMSGLINE("OSAlloc.c", 0x34F, !DLOverlap(HeapArray[i].free, start, end), "OSAddToHeap(): invalid range.");
-            ASSERTMSGLINE("OSAlloc.c", 0x351, !DLOverlap(HeapArray[i].allocated, start, end), "OSAddToHeap(): invalid range.");
+            ASSERTMSGLINE(0x34F, !DLOverlap(HeapArray[i].free, start, end), "OSAddToHeap(): invalid range.");
+            ASSERTMSGLINE(0x351, !DLOverlap(HeapArray[i].allocated, start, end), "OSAddToHeap(): invalid range.");
         }
     }
 #endif
@@ -460,7 +460,7 @@ void OSAddToHeap(int heap, void * start, void * end) {
 } 
 
 // custom macro for OSCheckHeap
-#define ASSERTREPORT(file, line, cond) \
+#define ASSERTREPORT(line, cond) \
     if (!(cond)) { OSReport("OSCheckHeap: Failed " #cond " in %d", line); return -1; }
 
 long OSCheckHeap(int heap) {
@@ -469,61 +469,61 @@ long OSCheckHeap(int heap) {
     long total = 0;
     long free = 0;
 
-    ASSERTREPORT("OSAlloc.c", 0x37D, HeapArray);
-    ASSERTREPORT("OSAlloc.c", 0x37E, 0 <= heap && heap < NumHeaps);
+    ASSERTREPORT(0x37D, HeapArray);
+    ASSERTREPORT(0x37E, 0 <= heap && heap < NumHeaps);
     hd = &HeapArray[heap];
-    ASSERTREPORT("OSAlloc.c", 0x381, 0 <= hd->size);
+    ASSERTREPORT(0x381, 0 <= hd->size);
     
-    ASSERTREPORT("OSAlloc.c", 0x383, hd->allocated == NULL || hd->allocated->prev == NULL);
+    ASSERTREPORT(0x383, hd->allocated == NULL || hd->allocated->prev == NULL);
 
     for(cell = hd->allocated; cell; cell = cell->next) {
-        ASSERTREPORT("OSAlloc.c", 0x386, InRange(cell, ArenaStart, ArenaEnd));
-        ASSERTREPORT("OSAlloc.c", 0x387, OFFSET(cell, ALIGNMENT) == 0);
-        ASSERTREPORT("OSAlloc.c", 0x388, cell->next == NULL || cell->next->prev == cell);
-        ASSERTREPORT("OSAlloc.c", 0x389, MINOBJSIZE <= cell->size);
-        ASSERTREPORT("OSAlloc.c", 0x38A, OFFSET(cell->size, ALIGNMENT) == 0);
+        ASSERTREPORT(0x386, InRange(cell, ArenaStart, ArenaEnd));
+        ASSERTREPORT(0x387, OFFSET(cell, ALIGNMENT) == 0);
+        ASSERTREPORT(0x388, cell->next == NULL || cell->next->prev == cell);
+        ASSERTREPORT(0x389, MINOBJSIZE <= cell->size);
+        ASSERTREPORT(0x38A, OFFSET(cell->size, ALIGNMENT) == 0);
         total += cell->size;
-        ASSERTREPORT("OSAlloc.c", 0x38D, 0 < total && total <= hd->size);
+        ASSERTREPORT(0x38D, 0 < total && total <= hd->size);
 #ifdef ENABLE_HEAPDESC
-        ASSERTREPORT("OSAlloc.c", 0x390, cell->hd == hd);
-        ASSERTREPORT("OSAlloc.c", 0x391, HEADERSIZE + cell->requested <= cell->size);
+        ASSERTREPORT(0x390, cell->hd == hd);
+        ASSERTREPORT(0x391, HEADERSIZE + cell->requested <= cell->size);
 #endif
     }
 
     
-    ASSERTREPORT("OSAlloc.c", 0x395, hd->free == NULL || hd->free->prev == NULL); 
+    ASSERTREPORT(0x395, hd->free == NULL || hd->free->prev == NULL); 
     
     for(cell = hd->free; cell; cell = cell->next) {
-        ASSERTREPORT("OSAlloc.c", 0x398, InRange(cell, ArenaStart, ArenaEnd));
-        ASSERTREPORT("OSAlloc.c", 0x399, OFFSET(cell, ALIGNMENT) == 0);
-        ASSERTREPORT("OSAlloc.c", 0x39A, cell->next == NULL || cell->next->prev == cell);
-        ASSERTREPORT("OSAlloc.c", 0x39B, MINOBJSIZE <= cell->size);
-        ASSERTREPORT("OSAlloc.c", 0x39C, OFFSET(cell->size, ALIGNMENT) == 0);
-        ASSERTREPORT("OSAlloc.c", 0x39D, cell->next == NULL || (char*) cell + cell->size < (char*) cell->next);
+        ASSERTREPORT(0x398, InRange(cell, ArenaStart, ArenaEnd));
+        ASSERTREPORT(0x399, OFFSET(cell, ALIGNMENT) == 0);
+        ASSERTREPORT(0x39A, cell->next == NULL || cell->next->prev == cell);
+        ASSERTREPORT(0x39B, MINOBJSIZE <= cell->size);
+        ASSERTREPORT(0x39C, OFFSET(cell->size, ALIGNMENT) == 0);
+        ASSERTREPORT(0x39D, cell->next == NULL || (char*) cell + cell->size < (char*) cell->next);
         total += cell->size;
         free = (cell->size + free);
         free -= HEADERSIZE;
-        ASSERTREPORT("OSAlloc.c", 0x3A1, 0 < total && total <= hd->size);
+        ASSERTREPORT(0x3A1, 0 < total && total <= hd->size);
 #ifdef ENABLE_HEAPDESC
-        ASSERTREPORT("OSAlloc.c", 0x3A4, cell->hd == NULL);
+        ASSERTREPORT(0x3A4, cell->hd == NULL);
 #endif
     }
-    ASSERTREPORT("OSAlloc.c", 0x3A8, total == hd->size);
+    ASSERTREPORT(0x3A8, total == hd->size);
     return free;
 }
 
 unsigned long OSReferentSize(void * ptr) {
     struct Cell * cell;
 
-    ASSERTMSGLINE("OSAlloc.c", 0x3BB, HeapArray, "OSReferentSize(): heap is not initialized.");
-    ASSERTMSGLINE("OSAlloc.c", 0x3BD, InRange(ptr, ArenaStart+HEADERSIZE, ArenaEnd), "OSReferentSize(): invalid pointer.");
-    ASSERTMSGLINE("OSAlloc.c", 0x3BE, !OFFSET(ptr, 32), "OSReferentSize(): invalid pointer.");
+    ASSERTMSGLINE(0x3BB, HeapArray, "OSReferentSize(): heap is not initialized.");
+    ASSERTMSGLINE(0x3BD, InRange(ptr, ArenaStart+HEADERSIZE, ArenaEnd), "OSReferentSize(): invalid pointer.");
+    ASSERTMSGLINE(0x3BE, !OFFSET(ptr, 32), "OSReferentSize(): invalid pointer.");
     cell = (void*)((u32)ptr-HEADERSIZE);
-    ASSERTMSGLINE("OSAlloc.c", 0x3C2, cell->hd, "OSReferentSize(): invalid pointer.");
-    ASSERTMSGLINE("OSAlloc.c", 0x3C4, !(((u32)cell->hd - (u32)HeapArray) % 24), "OSReferentSize(): invalid pointer.");
-    ASSERTMSGLINE("OSAlloc.c", 0x3C6, ((u32)HeapArray <= (u32)cell->hd) && ((u32)cell->hd < (u32)((u32)HeapArray + (NumHeaps * 0x18))), "OSReferentSize(): invalid pointer.");
-    ASSERTMSGLINE("OSAlloc.c", 0x3C7, cell->hd->size >= 0, "OSReferentSize(): invalid pointer.");
-    ASSERTMSGLINE("OSAlloc.c", 0x3C9, DLLookup(cell->hd->allocated, cell), "OSReferentSize(): invalid pointer.");
+    ASSERTMSGLINE(0x3C2, cell->hd, "OSReferentSize(): invalid pointer.");
+    ASSERTMSGLINE(0x3C4, !(((u32)cell->hd - (u32)HeapArray) % 24), "OSReferentSize(): invalid pointer.");
+    ASSERTMSGLINE(0x3C6, ((u32)HeapArray <= (u32)cell->hd) && ((u32)cell->hd < (u32)((u32)HeapArray + (NumHeaps * 0x18))), "OSReferentSize(): invalid pointer.");
+    ASSERTMSGLINE(0x3C7, cell->hd->size >= 0, "OSReferentSize(): invalid pointer.");
+    ASSERTMSGLINE(0x3C9, DLLookup(cell->hd->allocated, cell), "OSReferentSize(): invalid pointer.");
     return (long)((u32)cell->size-HEADERSIZE);
 }
 
@@ -532,14 +532,14 @@ void OSDumpHeap(int heap) {
     struct Cell * cell;
 
     OSReport("\nOSDumpHeap(%d):\n", heap);
-    ASSERTMSGLINE("OSAlloc.c", 0x3DE, HeapArray, "OSDumpHeap(): heap is not initialized.");
-    ASSERTMSGLINE("OSAlloc.c", 0x3DF, (heap >= 0) && (heap < NumHeaps), "OSDumpHeap(): invalid heap handle.");
+    ASSERTMSGLINE(0x3DE, HeapArray, "OSDumpHeap(): heap is not initialized.");
+    ASSERTMSGLINE(0x3DF, (heap >= 0) && (heap < NumHeaps), "OSDumpHeap(): invalid heap handle.");
     hd = &HeapArray[heap];
     if (hd->size < 0) {
         OSReport("--------Inactive\n");
         return;
     }
-    ASSERTMSGLINE("OSAlloc.c", 0x3E8, OSCheckHeap(heap) >= 0, "OSDumpHeap(): heap is broken.");
+    ASSERTMSGLINE(0x3E8, OSCheckHeap(heap) >= 0, "OSDumpHeap(): heap is broken.");
 #ifdef ENABLE_HEAPDESC
     OSReport("padding %d/(%f%%) header %d/(%f%%) payload %d/(%f%%)\n", 
         hd->paddingBytes, (100.0 * hd->paddingBytes / hd->size), hd->headerBytes, (100.0 * hd->headerBytes / hd->size), hd->payloadBytes,
@@ -548,7 +548,7 @@ void OSDumpHeap(int heap) {
     OSReport("addr	size		end	prev	next\n");
     OSReport("--------Allocated\n");
 
-    ASSERTMSGLINE("OSAlloc.c", 0x3F5, hd->allocated == NULL || hd->allocated->prev == NULL, "OSDumpHeap(): heap is broken.");
+    ASSERTMSGLINE(0x3F5, hd->allocated == NULL || hd->allocated->prev == NULL, "OSDumpHeap(): heap is broken.");
 
     for(cell = hd->allocated; cell; cell = cell->next) {
         OSReport("%x	%d	%x	%x	%x\n", cell, cell->size, (char*)cell + cell->size, cell->prev, cell->next);

--- a/src/os/OSArena.c
+++ b/src/os/OSArena.c
@@ -8,14 +8,14 @@ static void * __OSArenaHi;
 static void * __OSArenaLo = (void*)-1;
 
 void * OSGetArenaHi() {
-    ASSERTMSGLINE("OSArena.c", 0x37, (u32)__OSArenaLo != -1, "OSGetArenaHi(): OSInit() must be called in advance.");
-    ASSERTMSGLINE("OSArena.c", 0x39, (u32)__OSArenaLo <= (u32)__OSArenaHi, "OSGetArenaHi(): invalid arena (hi < lo).");
+    ASSERTMSGLINE(0x37, (u32)__OSArenaLo != -1, "OSGetArenaHi(): OSInit() must be called in advance.");
+    ASSERTMSGLINE(0x39, (u32)__OSArenaLo <= (u32)__OSArenaHi, "OSGetArenaHi(): invalid arena (hi < lo).");
     return __OSArenaHi;
 }
 
 void * OSGetArenaLo() {
-    ASSERTMSGLINE("OSArena.c", 0x49, (u32)__OSArenaLo != -1, "OSGetArenaLo(): OSInit() must be called in advance.");
-    ASSERTMSGLINE("OSArena.c", 0x4B, (u32)__OSArenaLo <= (u32)__OSArenaHi, "OSGetArenaLo(): invalid arena (hi < lo).");
+    ASSERTMSGLINE(0x49, (u32)__OSArenaLo != -1, "OSGetArenaLo(): OSInit() must be called in advance.");
+    ASSERTMSGLINE(0x4B, (u32)__OSArenaLo <= (u32)__OSArenaHi, "OSGetArenaLo(): invalid arena (hi < lo).");
     return __OSArenaLo;
 }
 

--- a/src/os/OSAudioSystem.c
+++ b/src/os/OSAudioSystem.c
@@ -25,9 +25,9 @@ void __OSInitAudioSystem(void) {
   DCFlushRange(__DSPWorkBuffer, 128);
 
   __DSPRegs[9] = 0x43;
-  ASSERTMSGLINE("OSAudioSystem.c", 0x67, !(__DSPRegs[5] & 0x200), "__OSInitAudioSystem(): ARAM DMA already in progress");
-  ASSERTMSGLINE("OSAudioSystem.c", 0x6B, !(__DSPRegs[5] & 0x400), "__OSInitAudioSystem(): DSP DMA already in progress");
-  ASSERTMSGLINE("OSAudioSystem.c", 0x6F, (__DSPRegs[5] & 0x004), "__OSInitAudioSystem(): DSP already working");
+  ASSERTMSGLINE(0x67, !(__DSPRegs[5] & 0x200), "__OSInitAudioSystem(): ARAM DMA already in progress");
+  ASSERTMSGLINE(0x6B, !(__DSPRegs[5] & 0x400), "__OSInitAudioSystem(): DSP DMA already in progress");
+  ASSERTMSGLINE(0x6F, (__DSPRegs[5] & 0x004), "__OSInitAudioSystem(): DSP already working");
   __DSPRegs[5] = 0x8AC;
   __DSPRegs[5] |= 1;
   while (__DSPRegs[5] & 1);
@@ -68,7 +68,7 @@ void __OSInitAudioSystem(void) {
   }
 
   if(((u32)((reg16 << 16) | __DSPRegs[3]) + 0x7FAC0000U) != 0x4348) {
-      ASSERTMSGLINE("OSAudioSystem.c", 0xB7, 0, "__OSInitAudioSystem(): DSP returns invalid message");
+      ASSERTMSGLINE(0xB7, 0, "__OSInitAudioSystem(): DSP returns invalid message");
   }
 
   reg16 != 42069;

--- a/src/os/OSCache.c
+++ b/src/os/OSCache.c
@@ -457,8 +457,8 @@ void LCAlloc(void * addr, unsigned long nBytes) {
     unsigned long numBlocks = nBytes >> 5;
     unsigned long hid2 = PPCMfhid2();
 
-    ASSERTMSGLINE("OSCache.c", 0x530, !((u32)addr & 31), "LCAlloc(): addr must be 32 byte aligned");
-    ASSERTMSGLINE("OSCache.c", 0x532, !((u32)nBytes & 31), "LCAlloc(): nBytes must be 32 byte aligned");
+    ASSERTMSGLINE(0x530, !((u32)addr & 31), "LCAlloc(): addr must be 32 byte aligned");
+    ASSERTMSGLINE(0x532, !((u32)nBytes & 31), "LCAlloc(): nBytes must be 32 byte aligned");
 
     if ((hid2 & 0x10000000) == 0) {
         LCEnable();
@@ -470,8 +470,8 @@ void LCAllocNoInvalidate(void * addr, unsigned long nBytes) {
     unsigned long numBlocks = nBytes >> 5;
     unsigned long hid2 = PPCMfhid2();
 
-    ASSERTMSGLINE("OSCache.c", 0x55F, !((u32)addr & 31), "LCAllocNoFlush(): addr must be 32 byte aligned");
-    ASSERTMSGLINE("OSCache.c", 0x561, !((u32)nBytes & 31), "LCAllocNoFlush(): nBytes must be 32 byte aligned");
+    ASSERTMSGLINE(0x55F, !((u32)addr & 31), "LCAllocNoFlush(): addr must be 32 byte aligned");
+    ASSERTMSGLINE(0x561, !((u32)nBytes & 31), "LCAllocNoFlush(): nBytes must be 32 byte aligned");
 
     if ((hid2 & 0x10000000) == 0) {
         LCEnable();
@@ -483,8 +483,8 @@ u32 LCLoadData(void* destAddr, void* srcAddr, u32 nBytes) {
   u32 numBlocks = (nBytes + 31) / 32;
   u32 numTransactions = (numBlocks + 128 - 1) / 128;
 
-  ASSERTMSGLINE("OSCache.c", 0x59B, !((u32)srcAddr & 31), "LCLoadData(): srcAddr not 32 byte aligned");
-  ASSERTMSGLINE("OSCache.c", 0x59D, !((u32)destAddr & 31), "LCLoadData(): destAddr not 32 byte aligned");
+  ASSERTMSGLINE(0x59B, !((u32)srcAddr & 31), "LCLoadData(): srcAddr not 32 byte aligned");
+  ASSERTMSGLINE(0x59D, !((u32)destAddr & 31), "LCLoadData(): destAddr not 32 byte aligned");
 
   while (numBlocks > 0) {
     if (numBlocks < 128) {
@@ -505,8 +505,8 @@ u32 LCStoreData(void* destAddr, void* srcAddr, u32 nBytes) {
   u32 numBlocks = (nBytes + 31) / 32;
   u32 numTransactions = (numBlocks + 128 - 1) / 128;
 
-  ASSERTMSGLINE("OSCache.c", 0x5DF, !((u32)srcAddr & 31), "LCStoreData(): srcAddr not 32 byte aligned");
-  ASSERTMSGLINE("OSCache.c", 0x5E1, !((u32)destAddr & 31), "LCStoreData(): destAddr not 32 byte aligned");
+  ASSERTMSGLINE(0x5DF, !((u32)srcAddr & 31), "LCStoreData(): srcAddr not 32 byte aligned");
+  ASSERTMSGLINE(0x5E1, !((u32)destAddr & 31), "LCStoreData(): destAddr not 32 byte aligned");
 
   while (numBlocks > 0) {
     if (numBlocks < 128) {

--- a/src/os/OSError.c
+++ b/src/os/OSError.c
@@ -35,7 +35,7 @@ void OSPanic(char* file, int line, char* msg, ...) {
 OSErrorHandler OSSetErrorHandler(OSError error, OSErrorHandler handler) {
     OSErrorHandler oldHandler;
 
-    ASSERTMSGLINE("OSError.c", 0x8F, error < __OS_EXCEPTION_MAX, "OSSetErrorHandler(): unknown error.");
+    ASSERTMSGLINE(0x8F, error < __OS_EXCEPTION_MAX, "OSSetErrorHandler(): unknown error.");
     oldHandler = OSErrorTable[error];
     OSErrorTable[error] = handler;
     return oldHandler;

--- a/src/os/OSExi.c
+++ b/src/os/OSExi.c
@@ -95,7 +95,7 @@ static void CompleteTransfer(long chan) {
     int len;
 
     exi = &Ecb[chan];
-    ASSERTLINE("OSExi.c", 0x115, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x115, 0 <= chan && chan < MAX_CHAN);
 
     if (exi->state & 3) {
         if (exi->state & 2) {
@@ -118,10 +118,10 @@ int EXIImm(long chan, void * buf, long len, unsigned long type, EXICallback call
     int i;
 
     exi = &Ecb[chan];
-    ASSERTLINE("OSExi.c", 0x13B, exi->state & STATE_SELECTED);
-    ASSERTLINE("OSExi.c", 0x13C, 0 <= chan && chan < MAX_CHAN);
-    ASSERTLINE("OSExi.c", 0x13D, 0 < len && len <= MAX_IMM);
-    ASSERTLINE("OSExi.c", 0x13E, type < MAX_TYPE);
+    ASSERTLINE(0x13B, exi->state & STATE_SELECTED);
+    ASSERTLINE(0x13C, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x13D, 0 < len && len <= MAX_IMM);
+    ASSERTLINE(0x13E, type < MAX_TYPE);
     enabled = OSDisableInterrupts();
     if ((exi->state & 3) || !(exi->state & 4)) {
         OSRestoreInterrupts(enabled);
@@ -170,11 +170,11 @@ int EXIDma(long chan, void * buf, long len, unsigned long type, EXICallback call
 
     exi = &Ecb[chan];
 
-    ASSERTLINE("OSExi.c", 0x1A4, exi->state & STATE_SELECTED);
-    ASSERTLINE("OSExi.c", 0x1A5, OFFSET(buf, 32) == 0);
-    ASSERTLINE("OSExi.c", 0x1A6, 0 < len && OFFSET(len, 32) == 0);
-    ASSERTLINE("OSExi.c", 0x1A8, ((u32) len & ~EXI_0LENGTH_EXILENGTH_MASK) == 0);
-    ASSERTLINE("OSExi.c", 0x1AA, type == EXI_READ || type == EXI_WRITE);
+    ASSERTLINE(0x1A4, exi->state & STATE_SELECTED);
+    ASSERTLINE(0x1A5, OFFSET(buf, 32) == 0);
+    ASSERTLINE(0x1A6, 0 < len && OFFSET(len, 32) == 0);
+    ASSERTLINE(0x1A8, ((u32) len & ~EXI_0LENGTH_EXILENGTH_MASK) == 0);
+    ASSERTLINE(0x1AA, type == EXI_READ || type == EXI_WRITE);
 
     enabled = OSDisableInterrupts();
     if ((exi->state & 3) || !(exi->state & 4)) {
@@ -201,7 +201,7 @@ int EXISync(long chan) {
 
     exi = &Ecb[chan];
     rc = 0;
-    ASSERTLINE("OSExi.c", 0x1D7, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x1D7, 0 <= chan && chan < MAX_CHAN);
     while ((exi->state & 4)) {
         if (!(__EXIRegs[(chan * 5) + 3] & 1)) {
             enabled = OSDisableInterrupts();
@@ -213,7 +213,7 @@ int EXISync(long chan) {
             break;
         }
     }
-    ASSERTLINE("OSExi.c", 0x1E9, !(exi->state & STATE_BUSY));
+    ASSERTLINE(0x1E9, !(exi->state & STATE_BUSY));
     return rc;
 }
 
@@ -221,7 +221,7 @@ unsigned long EXIClearInterrupts(long chan, int exi, int tc, int ext) {
     unsigned long cpr;
     unsigned long prev;
 
-    ASSERTLINE("OSExi.c", 0x1FE, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x1FE, 0 <= chan && chan < MAX_CHAN);
     cpr = prev = __EXIRegs[(chan * 5)];
     prev &= 0x7F5;
     if (exi != 0) {
@@ -243,7 +243,7 @@ EXICallback EXISetExiCallback(long chan, EXICallback exiCallback) {
     int enabled;
 
     exi = &Ecb[chan];
-    ASSERTLINE("OSExi.c", 0x220, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x220, 0 <= chan && chan < MAX_CHAN);
     enabled = OSDisableInterrupts();
     prev = exi->exiCallback;
     exi->exiCallback = exiCallback;
@@ -270,7 +270,7 @@ int EXIProbe(long chan) {
     long t;
 
     exi = &Ecb[chan];
-    ASSERTLINE("OSExi.c", 0x256, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x256, 0 <= chan && chan < MAX_CHAN);
     if (chan == 2) {
         return 1;
     }
@@ -318,7 +318,7 @@ int EXIAttach(long chan, EXICallback extCallback) {
     int enabled;
 
     exi = &Ecb[chan];
-    ASSERTLINE("OSExi.c", 0x2AE, 0 <= chan && chan < 2);
+    ASSERTLINE(0x2AE, 0 <= chan && chan < 2);
     enabled = OSDisableInterrupts();
     if (exi->state & 8) {
         OSRestoreInterrupts(enabled);
@@ -341,7 +341,7 @@ int EXIDetach(long chan) {
     int enabled;
 
     exi = &Ecb[chan];
-    ASSERTLINE("OSExi.c", 0x2D7, 0 <= chan && chan < 2);
+    ASSERTLINE(0x2D7, 0 <= chan && chan < 2);
     enabled = OSDisableInterrupts();
     if (!(exi->state & 8)) {
         OSRestoreInterrupts(enabled);
@@ -364,10 +364,10 @@ int EXISelect(long chan, unsigned long dev, unsigned long freq) {
 
     exi = &Ecb[chan];
 
-    ASSERTLINE("OSExi.c", 0x2FF, 0 <= chan && chan < MAX_CHAN);
-    ASSERTLINE("OSExi.c", 0x300, chan == 0 && dev < MAX_DEV || dev == 0);
-    ASSERTLINE("OSExi.c", 0x301, freq < MAX_FREQ);
-    ASSERTLINE("OSExi.c", 0x302, !(exi->state & STATE_SELECTED));
+    ASSERTLINE(0x2FF, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x300, chan == 0 && dev < MAX_DEV || dev == 0);
+    ASSERTLINE(0x301, freq < MAX_FREQ);
+    ASSERTLINE(0x302, !(exi->state & STATE_SELECTED));
 
     enabled = OSDisableInterrupts();
     if ((exi->state & 4) || ((chan != 2) && (((dev == 0) && !(exi->state & 8) && (EXIProbe(chan) == 0)) || !(exi->state & 0x10) || (exi->dev != dev)))) {
@@ -399,7 +399,7 @@ int EXIDeselect(long chan) {
     int enabled;
 
     exi = &Ecb[chan];
-    ASSERTLINE("OSExi.c", 0x335, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x335, 0 <= chan && chan < MAX_CHAN);
     enabled = OSDisableInterrupts();
     if (!(exi->state & 4)) {
         OSRestoreInterrupts(enabled);
@@ -435,7 +435,7 @@ static void EXIIntrruptHandler(signed short interrupt, struct OSContext * contex
 
     chan = (interrupt-9)/3;
 
-    ASSERTLINE("OSExi.c", 0x368, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x368, 0 <= chan && chan < MAX_CHAN);
     exi = &Ecb[chan];
     EXIClearInterrupts(chan, 1, 0, 0);
     callback = exi->exiCallback;
@@ -451,7 +451,7 @@ static void TCIntrruptHandler(signed short interrupt, struct OSContext * context
 
     chan = (interrupt-10)/3;
 
-    ASSERTLINE("OSExi.c", 0x383, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x383, 0 <= chan && chan < MAX_CHAN);
     exi = &Ecb[chan];
     __OSMaskInterrupts(0x80000000U >> interrupt);
     EXIClearInterrupts(chan, 0, 1, 0);
@@ -470,7 +470,7 @@ static void EXTIntrruptHandler(signed short interrupt, struct OSContext * contex
 
     chan = (interrupt-11)/3;
 
-    ASSERTLINE("OSExi.c", 0x3A2, 0 <= chan && chan < 2);
+    ASSERTLINE(0x3A2, 0 <= chan && chan < 2);
     __OSMaskInterrupts(0x700000U >> (chan * 3));
     __EXIRegs[(chan * 5)] = 0;
     exi = &Ecb[chan];
@@ -507,13 +507,13 @@ int EXILock(long chan, unsigned long dev, void (* unlockedCallback)(long, struct
     int i;
 
     exi = &Ecb[chan];
-    ASSERTLINE("OSExi.c", 0x3F2, 0 <= chan && chan < MAX_CHAN);
-    ASSERTLINE("OSExi.c", 0x3F3, chan == 0 && dev < MAX_DEV || dev == 0);
+    ASSERTLINE(0x3F2, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x3F3, chan == 0 && dev < MAX_DEV || dev == 0);
     enabled = OSDisableInterrupts();
 
     if (exi->state & 0x10) {
         if (unlockedCallback) {
-            ASSERTLINE("OSExi.c", 0x3F9, chan == 0 && exi->items < (MAX_DEV - 1)|| exi->items == 0);
+            ASSERTLINE(0x3F9, chan == 0 && exi->items < (MAX_DEV - 1)|| exi->items == 0);
             for(i = 0; i < exi->items; i++) {
                 if (exi->queue[i].dev == dev) {
                     OSRestoreInterrupts(enabled);
@@ -527,7 +527,7 @@ int EXILock(long chan, unsigned long dev, void (* unlockedCallback)(long, struct
         OSRestoreInterrupts(enabled);
         return 0;
     }
-    ASSERTLINE("OSExi.c", 0x409, exi->items == 0);
+    ASSERTLINE(0x409, exi->items == 0);
     exi->state |= 0x10;
     exi->dev = dev;
     SetExiInterruptMask(chan, exi);
@@ -541,7 +541,7 @@ int EXIUnlock(long chan) {
     EXICallback unlockedCallback;
 
     exi = &Ecb[chan];
-    ASSERTLINE("OSExi.c", 0x421, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x421, 0 <= chan && chan < MAX_CHAN);
     enabled = OSDisableInterrupts();
     if (!(exi->state & 0x10)) {
         OSRestoreInterrupts(enabled);
@@ -564,7 +564,7 @@ unsigned long EXIGetState(long chan) {
     struct EXIControl * exi;
 
     exi = &Ecb[chan];
-    ASSERTLINE("OSExi.c", 0x446, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x446, 0 <= chan && chan < MAX_CHAN);
     return exi->state;
 }
 
@@ -572,7 +572,7 @@ int EXIGetID(long chan, unsigned long dev, unsigned long * id) {
     int err;
     unsigned long cmd;
 
-    ASSERTLINE("OSExi.c", 0x45A, 0 <= chan && chan < MAX_CHAN);
+    ASSERTLINE(0x45A, 0 <= chan && chan < MAX_CHAN);
     if ((chan != 2) && (dev == 0) && (EXIAttach(chan, 0) == 0)) {
         return 0;
     }

--- a/src/os/OSFont.c
+++ b/src/os/OSFont.c
@@ -377,7 +377,7 @@ char * OSGetFontTexel(char * string, void * image, long pos, long stride , long 
     unsigned char * colorIndex;
     unsigned char * imageSrc;
 
-    ASSERTLINE("OSFont.c", 0x1F6, FontData && !SheetImage);
+    ASSERTLINE(0x1F6, FontData && !SheetImage);
     
     code = *string;
     if (code == '\0') {
@@ -392,7 +392,7 @@ char * OSGetFontTexel(char * string, void * image, long pos, long stride , long 
     }
     colorIndex = &FontData->c0;
 
-    ASSERTLINE("OSFont.c", 0x209, FontData->sheetFormat == GX_TF_I4);
+    ASSERTLINE(0x209, FontData->sheetFormat == GX_TF_I4);
 
     fontCode = GetFontCode(code);
 
@@ -480,8 +480,8 @@ char * OSGetFontTexture(char * string, void ** image, long * x, long * y, long *
     int row;
     int column;
 
-    ASSERTLINE("OSFont.c", 0x291, SheetImage);
-    ASSERTLINE("OSFont.c", 0x292, WidthTable);
+    ASSERTLINE(0x291, SheetImage);
+    ASSERTLINE(0x292, WidthTable);
 
     code = *string;
     if (code == 0) {
@@ -515,7 +515,7 @@ char * OSGetFontTexture(char * string, void ** image, long * x, long * y, long *
 char * OSGetFontWidth(char * string, long * width) {
     unsigned short code;
 
-    ASSERTLINE("OSFont.c", 0x2C2, WidthTable);
+    ASSERTLINE(0x2C2, WidthTable);
 
     code = *string;
     if (code == 0) {

--- a/src/os/OSInterrupt.c
+++ b/src/os/OSInterrupt.c
@@ -124,8 +124,8 @@ __OSInterruptHandler
   __OSInterruptHandler oldHandler;
   
         
-  ASSERTMSGLINE("OSInterrupt.c", 0x188, InterruptHandlerTable, "__OSSetInterruptHandler(): OSInit() must be called in advance.");
-  ASSERTMSGLINE("OSInterrupt.c", 0x18A, interrupt < 0x20, "__OSSetInterruptHandler(): unknown interrupt.");
+  ASSERTMSGLINE(0x188, InterruptHandlerTable, "__OSSetInterruptHandler(): OSInit() must be called in advance.");
+  ASSERTMSGLINE(0x18A, interrupt < 0x20, "__OSSetInterruptHandler(): unknown interrupt.");
 
   oldHandler = InterruptHandlerTable[interrupt];
   InterruptHandlerTable[interrupt] = handler;
@@ -133,8 +133,8 @@ __OSInterruptHandler
 }
 
 __OSInterruptHandler __OSGetInterruptHandler(__OSInterrupt interrupt) {
-  ASSERTMSGLINE("OSInterrupt.c", 0x19E, InterruptHandlerTable, "__OSGetInterruptHandler(): OSInit() must be called in advance.");
-  ASSERTMSGLINE("OSInterrupt.c", 0x1A0, interrupt < 0x20, "__OSGetInterruptHandler(): unknown interrupt.");
+  ASSERTMSGLINE(0x19E, InterruptHandlerTable, "__OSGetInterruptHandler(): OSInit() must be called in advance.");
+  ASSERTMSGLINE(0x1A0, interrupt < 0x20, "__OSGetInterruptHandler(): unknown interrupt.");
   return InterruptHandlerTable[interrupt];
 }
 

--- a/src/os/OSLink.c
+++ b/src/os/OSLink.c
@@ -215,7 +215,7 @@ BOOL OSLink(OSModuleInfo* newModule, void* bss) {
   OSModuleInfo* moduleInfo;
   OSImportInfo* imp;
 
-  ASSERTLINE("OSLink.c", 0xEB, newModule->version == OS_MODULE_VERSION);
+  ASSERTLINE(0xEB, newModule->version == OS_MODULE_VERSION);
 
   moduleHeader = (OSModuleHeader*)newModule;
 
@@ -279,9 +279,9 @@ static BOOL Undo(OSModuleHeader* newModule, OSModuleHeader* module) {
   u32 offset;
   u32 x;
 
-  ASSERTLINE("OSLink.c", 0x147, newModule);
+  ASSERTLINE(0x147, newModule);
   idNew = newModule->info.id;
-  ASSERTLINE("OSLink.c", 0x149, idNew);
+  ASSERTLINE(0x149, idNew);
   
   for (imp = (OSImportInfo*)module->impOffset;
        imp < (OSImportInfo*)(module->impOffset + module->impSize); imp++) {
@@ -356,7 +356,7 @@ BOOL OSUnlink(OSModuleInfo* oldModule) {
   OSModuleHeader* moduleHeader;
   OSModuleInfo* moduleInfo;
 
-  ASSERTLINE("OSLink.c", 0x1AA, oldModule->version == OS_MODULE_VERSION);
+  ASSERTLINE(0x1AA, oldModule->version == OS_MODULE_VERSION);
   moduleHeader = (OSModuleHeader*)oldModule;
 
   DEQUEUE_INFO(oldModule, &__OSModuleInfoList, link);

--- a/src/os/OSMutex.c
+++ b/src/os/OSMutex.c
@@ -68,8 +68,8 @@ void OSLockMutex(struct OSMutex * mutex) {
     int enabled = OSDisableInterrupts();
     struct OSThread * currentThread = OSGetCurrentThread();
 
-    ASSERTMSGLINE("OSMutex.c", 0x8C, currentThread, "OSLockMutex(): current thread does not exist.");
-    ASSERTMSGLINE("OSMutex.c", 0x8E, currentThread->state == 2, "OSLockMutex(): current thread is not running.");
+    ASSERTMSGLINE(0x8C, currentThread, "OSLockMutex(): current thread does not exist.");
+    ASSERTMSGLINE(0x8E, currentThread->state == 2, "OSLockMutex(): current thread is not running.");
     
     while(1) {
         struct OSThread * ownerThread = mutex->thread;
@@ -84,7 +84,7 @@ void OSLockMutex(struct OSMutex * mutex) {
         } else {
             currentThread->mutex = mutex;
             __OSPromoteThread(mutex->thread, currentThread->priority);
-            ASSERTMSG2LINE("OSMutex.c", 0xA4, __OSCheckDeadLock(currentThread) == 0, "OSLockMutex(): detected deadlock: current thread %p, mutex %p.", currentThread, mutex);
+            ASSERTMSG2LINE(0xA4, __OSCheckDeadLock(currentThread) == 0, "OSLockMutex(): detected deadlock: current thread %p, mutex %p.", currentThread, mutex);
             OSSleepThread(&mutex->queue);
             currentThread->mutex = NULL;
         }
@@ -96,9 +96,9 @@ void OSUnlockMutex(struct OSMutex * mutex) {
     int enabled = OSDisableInterrupts();
     struct OSThread * currentThread = OSGetCurrentThread();
 
-    ASSERTMSGLINE("OSMutex.c", 0xBD, currentThread, "OSUnlockMutex(): current thread does not exist.");
-    ASSERTMSGLINE("OSMutex.c", 0xBF, currentThread->state == 2, "OSUnlockMutex(): current thread is not running.");
-    ASSERTMSG2LINE("OSMutex.c", 0xC2, mutex->thread == currentThread, "OSUnlockMutex(): current thread %p is not the owner of mutex %p.", currentThread, mutex);
+    ASSERTMSGLINE(0xBD, currentThread, "OSUnlockMutex(): current thread does not exist.");
+    ASSERTMSGLINE(0xBF, currentThread->state == 2, "OSUnlockMutex(): current thread is not running.");
+    ASSERTMSG2LINE(0xC2, mutex->thread == currentThread, "OSUnlockMutex(): current thread %p is not the owner of mutex %p.", currentThread, mutex);
 
     if (mutex->thread == currentThread) {
         if(!--mutex->count) {
@@ -120,7 +120,7 @@ void __OSUnlockAllMutex(struct OSThread * thread) {
     while(thread->queueMutex.head) {
         mutex = thread->queueMutex.head;
         DEQUEUE_HEAD(mutex, &thread->queueMutex, link);
-        ASSERTLINE("OSMutex.c", 0xE5, mutex->thread == thread);
+        ASSERTLINE(0xE5, mutex->thread == thread);
         mutex->count = 0;
         mutex->thread = 0;
         OSWakeupThread(&mutex->queue);
@@ -132,8 +132,8 @@ int OSTryLockMutex(struct OSMutex * mutex) {
     struct OSThread * currentThread = OSGetCurrentThread();
     int locked;
 
-    ASSERTMSGLINE("OSMutex.c", 0xFF, currentThread, "OSTryLockMutex(): current thread does not exist.");
-    ASSERTMSGLINE("OSMutex.c", 0x101, currentThread->state == 2, "OSTryLockMutex(): current thread is not running.");
+    ASSERTMSGLINE(0xFF, currentThread, "OSTryLockMutex(): current thread does not exist.");
+    ASSERTMSGLINE(0x101, currentThread->state == 2, "OSTryLockMutex(): current thread is not running.");
 
     if (!mutex->thread) {
         mutex->thread = currentThread;
@@ -158,9 +158,9 @@ void OSWaitCond(struct OSCond * cond, struct OSMutex * mutex) {
     int enabled = OSDisableInterrupts();
     struct OSThread * currentThread = OSGetCurrentThread();
 
-    ASSERTMSGLINE("OSMutex.c", 0x139, currentThread, "OSWaitCond(): current thread does not exist.");
-    ASSERTMSGLINE("OSMutex.c", 0x13B, currentThread->state == 2, "OSWaitCond(): current thread is not running.");
-    ASSERTMSG2LINE("OSMutex.c", 0x13E, mutex->thread == currentThread, "OSWaitCond(): current thread %p is not the owner of mutex %p.", currentThread, mutex);
+    ASSERTMSGLINE(0x139, currentThread, "OSWaitCond(): current thread does not exist.");
+    ASSERTMSGLINE(0x13B, currentThread->state == 2, "OSWaitCond(): current thread is not running.");
+    ASSERTMSG2LINE(0x13E, mutex->thread == currentThread, "OSWaitCond(): current thread %p is not the owner of mutex %p.", currentThread, mutex);
 
     if (mutex->thread == currentThread) {
         long count = mutex->count;

--- a/src/os/OSReset.c
+++ b/src/os/OSReset.c
@@ -61,7 +61,7 @@ static int CallResetFunctions(int final);
 static asm void Reset(unsigned long resetCode);
 
 void OSRegisterResetFunction(struct OSResetFunctionInfo * info) {
-    ASSERTLINE("OSReset.c", 0x76, info->func);
+    ASSERTLINE(0x76, info->func);
 
     ENQUEUE_INFO_PRIO(info, &ResetFunctionQueue);
 }
@@ -142,7 +142,7 @@ void OSResetSystem(int reset, unsigned long resetCode, int forceMenu) {
     }
     enabled = OSDisableInterrupts();
     rc = CallResetFunctions(1);
-    ASSERTLINE("OSReset.c", 0x117, rc);
+    ASSERTLINE(0x117, rc);
     if (reset != 0) {
         ICFlashInvalidate();
         Reset(resetCode * 8);

--- a/src/os/OSRtc.c
+++ b/src/os/OSRtc.c
@@ -105,12 +105,12 @@ static int ReadSram(void * buffer) {
 
 static void WriteSramCallback() {
     int unused;
-    ASSERTLINE("OSRtc.c", 0xF0, !Scb.locked);
+    ASSERTLINE(0xF0, !Scb.locked);
     Scb.sync = WriteSram(&Scb.sram[Scb.offset], Scb.offset, 0x40 - Scb.offset);
     if (Scb.sync != 0) {
         Scb.offset = 0x40;
     }
-    ASSERTLINE("OSRtc.c", 0xF6, Scb.sync);
+    ASSERTLINE(0xF6, Scb.sync);
 }
 
 static int WriteSram(void * buffer, unsigned long offset, unsigned long size) {
@@ -138,7 +138,7 @@ static int WriteSram(void * buffer, unsigned long offset, unsigned long size) {
 void __OSInitSram() {
     Scb.locked = Scb.enabled = 0;
     Scb.sync = ReadSram(&Scb);
-    ASSERTLINE("OSRtc.c", 0x12C, Scb.sync);
+    ASSERTLINE(0x12C, Scb.sync);
     Scb.offset = 0x40;
 }
 
@@ -146,7 +146,7 @@ static void * LockSram(unsigned long offset) {
     int enabled;
 
     enabled = OSDisableInterrupts();
-    ASSERTLINE("OSRtc.c", 0x140, !Scb.locked);
+    ASSERTLINE(0x140, !Scb.locked);
     if (Scb.locked) {
         OSRestoreInterrupts(enabled);
         return NULL;
@@ -167,7 +167,7 @@ struct OSSramEx * __OSLockSramEx(void) {
 static int UnlockSram(int commit, unsigned long offset) {
     unsigned short * p;
 
-    ASSERTLINE("OSRtc.c", 0x162, Scb.locked);
+    ASSERTLINE(0x162, Scb.locked);
     if (commit != 0) {
         if (offset == 0) {
             struct OSSram * sram  = (struct OSSram *)&Scb.sram[0];
@@ -209,7 +209,7 @@ int __OSCheckSram() {
     struct OSSram * sram;
     int unused;
 
-    ASSERTLINE("OSRtc.c", 0x1A9, Scb.locked);
+    ASSERTLINE(0x1A9, Scb.locked);
 
     checkSum = checkSumInv = 0;
 
@@ -227,7 +227,7 @@ int __OSReadROM(void * buffer, long length, long offset) {
     int err;
     unsigned long cmd;
 
-    ASSERTLINE("OSRtc.c", 0x1C8, length <= 1024);
+    ASSERTLINE(0x1C8, length <= 1024);
     DCInvalidateRange(buffer, length);
     if (EXILock(0, 1, NULL) == 0) {
         return 0;
@@ -263,8 +263,8 @@ int __OSReadROMAsync(void * buffer, long length, long offset, void (* callback)(
     int err;
     unsigned long cmd;
 
-    ASSERTLINE("OSRtc.c", 0x203, length <= 1024);
-    ASSERTLINE("OSRtc.c", 0x204, callback);
+    ASSERTLINE(0x203, length <= 1024);
+    ASSERTLINE(0x204, callback);
     DCInvalidateRange(buffer, length);
     Scb.callback = callback;
     if (EXILock(0, 1, NULL) == 0) {
@@ -294,7 +294,7 @@ void OSSetSoundMode(unsigned long mode) {
     struct OSSram * sram;
     int unused;
 
-    ASSERTLINE("OSRtc.c", 0x22A, mode == OS_SOUND_MODE_MONO || mode == OS_SOUND_MODE_STEREO);
+    ASSERTLINE(0x22A, mode == OS_SOUND_MODE_MONO || mode == OS_SOUND_MODE_STEREO);
     mode *= 4;
     mode &= 4;
     sram = __OSLockSram();
@@ -319,7 +319,7 @@ void OSSetVideoMode(unsigned long mode) {
     struct OSSram * sram;
     int unused;
 
-    ASSERTLINE("OSRtc.c", 0x249, OS_VIDEO_MODE_NTSC <= mode && mode <= OS_VIDEO_MODE_MPAL);
+    ASSERTLINE(0x249, OS_VIDEO_MODE_NTSC <= mode && mode <= OS_VIDEO_MODE_MPAL);
 
     mode &= 3;
     sram = __OSLockSram();

--- a/src/os/OSSerial.c
+++ b/src/os/OSSerial.c
@@ -80,7 +80,7 @@ static void SIIntrruptHandler(short unused, struct OSContext * context) {
     unsigned long sr;
     void (* callback)(long, unsigned long, struct OSContext *);
 
-    ASSERTLINE("OSSerial.c", 0xE2, Si.chan != CHAN_NONE);
+    ASSERTLINE(0xE2, Si.chan != CHAN_NONE);
 
     chan = Si.chan;
     sr = CompleteTransfer();
@@ -124,16 +124,16 @@ static int __SITransfer(long chan, void * output, unsigned long outputBytes, voi
         } f;
     } comcsr;
 
-    ASSERTMSGLINE("OSSerial.c", 0x12A, (chan >= 0) && (chan < 4), "SITransfer(): invalid channel.");
-    ASSERTMSGLINE("OSSerial.c", 0x12C, (outputBytes != 0) && (outputBytes <= 128), "SITransfer(): output size is out of range (must be 1 to 128).");
-    ASSERTMSGLINE("OSSerial.c", 0x12E, (inputBytes != 0) && (inputBytes <= 128), "SITransfer(): input size is out of range (must be 1 to 128).");
+    ASSERTMSGLINE(0x12A, (chan >= 0) && (chan < 4), "SITransfer(): invalid channel.");
+    ASSERTMSGLINE(0x12C, (outputBytes != 0) && (outputBytes <= 128), "SITransfer(): output size is out of range (must be 1 to 128).");
+    ASSERTMSGLINE(0x12E, (inputBytes != 0) && (inputBytes <= 128), "SITransfer(): input size is out of range (must be 1 to 128).");
 
     enabled = OSDisableInterrupts();
     if (Si.chan != -1) {
         OSRestoreInterrupts(enabled);
         return 0;
     }
-    ASSERTLINE("OSSerial.c", 0x138, (__SIRegs[SI_COMCSR_IDX] & (SI_COMCSR_TSTART_MASK | SI_COMCSR_TCINT_MASK)) == 0);
+    ASSERTLINE(0x138, (__SIRegs[SI_COMCSR_IDX] & (SI_COMCSR_TSTART_MASK | SI_COMCSR_TCINT_MASK)) == 0);
     sr = __SIRegs[SI_STATUS_IDX];
     sr &= (0x0F000000 >> (chan * 8));
     __SIRegs[SI_STATUS_IDX] = sr;
@@ -179,12 +179,12 @@ unsigned long SIGetStatus() {
 }
 
 void SISetCommand(long chan, unsigned long command) {
-    ASSERTMSGLINE("OSSerial.c", 0x197, (chan >= 0) && (chan < 4), "SISetCommand(): invalid channel.");
+    ASSERTMSGLINE(0x197, (chan >= 0) && (chan < 4), "SISetCommand(): invalid channel.");
     __SIRegs[chan * 3] = command;
 }
 
 unsigned long SIGetCommand(long chan) {
-    ASSERTMSGLINE("OSSerial.c", 0x1A9, (chan >= 0) && (chan < 4), "SIGetCommand(): invalid channel.");
+    ASSERTMSGLINE(0x1A9, (chan >= 0) && (chan < 4), "SIGetCommand(): invalid channel.");
     return __SIRegs[chan * 3];
 }
 
@@ -196,9 +196,9 @@ unsigned long SISetXY(unsigned long x, unsigned long y) {
     unsigned long poll;
     int enabled;
 
-    ASSERTMSGLINE("OSSerial.c", 0x1CA, x >= 8, "SISetXY(): x is out of range (8 <= x <= 255)");
-    ASSERTMSGLINE("OSSerial.c", 0x1CB, x <= 255, "SISetXY(): x is out of range (8 <= x <= 255)");
-    ASSERTMSGLINE("OSSerial.c", 0x1CC, y <= 255, "SISetXY(): y is out of range (0 <= y <= 255)");
+    ASSERTMSGLINE(0x1CA, x >= 8, "SISetXY(): x is out of range (8 <= x <= 255)");
+    ASSERTMSGLINE(0x1CB, x <= 255, "SISetXY(): x is out of range (8 <= x <= 255)");
+    ASSERTMSGLINE(0x1CC, y <= 255, "SISetXY(): y is out of range (0 <= y <= 255)");
 
     poll = x << 0x10;
     poll |= y << 8;
@@ -214,7 +214,7 @@ unsigned long SIEnablePolling(unsigned long poll) {
     int enabled;
     unsigned long en;
 
-    ASSERTMSGLINE("OSSerial.c", 0x1E8, !(poll & 0x0FFFFFFF), "SIEnablePolling(): invalid chan bit(s).");
+    ASSERTMSGLINE(0x1E8, !(poll & 0x0FFFFFFF), "SIEnablePolling(): invalid chan bit(s).");
     if (poll == 0) {
         return Si.poll;
     }
@@ -223,7 +223,7 @@ unsigned long SIEnablePolling(unsigned long poll) {
     __SIRegs[0x30/4] = 0;
     poll = poll >> 24;
     en = poll & 0xF0;
-    ASSERTLINE("OSSerial.c", 0x202, en);
+    ASSERTLINE(0x202, en);
     poll &= ((en >> 4) | 0x03FFFFF0);
     poll &= 0xFC0000FF;
     
@@ -239,14 +239,14 @@ unsigned long SIEnablePolling(unsigned long poll) {
 unsigned long SIDisablePolling(unsigned long poll) {
     int enabled;
 
-    ASSERTMSGLINE("OSSerial.c", 0x22D, !(poll & 0x0FFFFFFF), "SIDisablePolling(): invalid chan bit(s).");
+    ASSERTMSGLINE(0x22D, !(poll & 0x0FFFFFFF), "SIDisablePolling(): invalid chan bit(s).");
     if (poll == 0) {
         return Si.poll;
     }
     enabled = OSDisableInterrupts();
     poll = poll >> 24;
     poll &= 0xF0;
-    ASSERTLINE("OSSerial.c", 0x23A, poll);
+    ASSERTLINE(0x23A, poll);
     poll = Si.poll & ~poll;
     __SIRegs[0x30/4] = poll;
     Si.poll = poll;
@@ -255,7 +255,7 @@ unsigned long SIDisablePolling(unsigned long poll) {
 }
 
 void SIGetResponse(long chan, void * data) {
-    ASSERTMSGLINE("OSSerial.c", 0x250, ((chan >= 0) && (chan < 4)), "SIGetResponse(): invalid channel.");
+    ASSERTMSGLINE(0x250, ((chan >= 0) && (chan < 4)), "SIGetResponse(): invalid channel.");
     ((u32*)data)[0] = __SIRegs[chan * 3 + 1];
     ((u32*)data)[1] = __SIRegs[chan * 3 + 2];
 }
@@ -266,8 +266,8 @@ static void AlarmHandler(struct OSAlarm * alarm, struct OSContext * context) {
 
     chan = alarm-Alarm;
 
-    ASSERTLINE("OSSerial.c", 0x266, 0 <= chan && chan < SI_MAX_CHAN);
-    ASSERTLINE("OSSerial.c", 0x267, packet->time <= OSGetTime()); // WTF? Dereferencing a NULL POINTER?
+    ASSERTLINE(0x266, 0 <= chan && chan < SI_MAX_CHAN);
+    ASSERTLINE(0x267, packet->time <= OSGetTime()); // WTF? Dereferencing a NULL POINTER?
     packet = &Packet[chan];
 
     if (packet->chan != -1 && __SITransfer(packet->chan, packet->output, packet->outputBytes, packet->input, packet->inputBytes, packet->callback)) {

--- a/src/os/OSThread.c
+++ b/src/os/OSThread.c
@@ -130,7 +130,7 @@ void __OSThreadInit() {
     thread->queueMutex.head = thread->queueMutex.tail = 0; // it got inlined? cant reproduce the inline...
 #endif
 
-    ASSERTLINE("OSThread.c", 282, PPCMfmsr() & MSR_FP);
+    ASSERTLINE(282, PPCMfmsr() & MSR_FP);
 
     __gUnkThread1 = thread;
     OSClearContext(&thread->context);
@@ -222,10 +222,10 @@ long OSEnableScheduler() {
 }
 
 static void SetRun(struct OSThread * thread) {
-    ASSERTLINE("OSThread.c", 469, !IsSuspended(thread->suspend));
-    ASSERTLINE("OSThread.c", 470, thread->state == OS_THREAD_STATE_READY);
+    ASSERTLINE(469, !IsSuspended(thread->suspend));
+    ASSERTLINE(470, thread->state == OS_THREAD_STATE_READY);
     
-    ASSERTLINE("OSThread.c", 472, OS_PRIORITY_MIN <= thread->priority && thread->priority <= OS_PRIORITY_MAX);
+    ASSERTLINE(472, OS_PRIORITY_MIN <= thread->priority && thread->priority <= OS_PRIORITY_MAX);
 
     thread->queue = &RunQueue[thread->priority];
 
@@ -238,10 +238,10 @@ static void SetRun(struct OSThread * thread) {
 static void UnsetRun(struct OSThread * thread) {
     struct OSThreadQueue * queue;
 
-    ASSERTLINE("OSThread.c", 0x1ED, thread->state == OS_THREAD_STATE_READY);
+    ASSERTLINE(0x1ED, thread->state == OS_THREAD_STATE_READY);
     
-    ASSERTLINE("OSThread.c", 0x1EF, OS_PRIORITY_MIN <= thread->priority && thread->priority <= OS_PRIORITY_MAX);
-    ASSERTLINE("OSThread.c", 0x1F0, thread->queue == &RunQueue[thread->priority]);
+    ASSERTLINE(0x1EF, OS_PRIORITY_MIN <= thread->priority && thread->priority <= OS_PRIORITY_MAX);
+    ASSERTLINE(0x1F0, thread->queue == &RunQueue[thread->priority]);
 
     queue = thread->queue;
 
@@ -267,7 +267,7 @@ long __OSGetEffectivePriority(struct OSThread * thread) {
 }
 
 static struct OSThread * SetEffectivePriority(struct OSThread * thread, long priority) {
-    ASSERTLINE("OSThread.c", 547, !IsSuspended(thread->suspend));
+    ASSERTLINE(547, !IsSuspended(thread->suspend));
 
     switch(thread->state) {
         case 1:
@@ -282,7 +282,7 @@ static struct OSThread * SetEffectivePriority(struct OSThread * thread, long pri
             ENQUEUE_THREAD_PRIO(thread, thread->queue, link);
 
             if(thread->mutex) {
-                ASSERTLINE("OSThread.c", 0x232, thread->mutex->thread);
+                ASSERTLINE(0x232, thread->mutex->thread);
                 return thread->mutex->thread;
             }
             break;
@@ -372,14 +372,14 @@ static struct OSThread * SelectThread(int yield) {
     RunQueueHint = 0;
     priority = __cntlzw(RunQueueBits);
 
-    ASSERTLINE("OSThread.c", 0x2C6, OS_PRIORITY_MIN <= priority && priority <= OS_PRIORITY_MAX);
+    ASSERTLINE(0x2C6, OS_PRIORITY_MIN <= priority && priority <= OS_PRIORITY_MAX);
 
     queue = &RunQueue[priority];
     nextThread = queue->head;
 
     DEQUEUE_HEAD(nextThread, queue, link);
 
-    ASSERTLINE("OSThread.c", 0x2C9, nextThread->priority == priority);
+    ASSERTLINE(0x2C9, nextThread->priority == priority);
 
     if (!queue->head) {
         RunQueueBits &= ~(1 << (0x1F - priority));
@@ -407,7 +407,7 @@ int OSCreateThread(struct OSThread * thread, void * (* func)(void *), void * par
     int enabled; // r25
     unsigned long sp; // r30
 
-    ASSERTMSGLINE("OSThread.c", 0x31C, ((priority >= 0) && (priority <= 0x1F)), "OSCreateThread(): priority out of range (0 <= priority <= 31).");
+    ASSERTMSGLINE(0x31C, ((priority >= 0) && (priority <= 0x1F)), "OSCreateThread(): priority out of range (0 <= priority <= 31).");
 
     // why check this for an assert just to check it again right after?
     if ((priority < 0) || (priority > 0x1F)) {
@@ -440,7 +440,7 @@ int OSCreateThread(struct OSThread * thread, void * (* func)(void *), void * par
     *thread->stackEnd = 0xDEADBABE;
     enabled = OSDisableInterrupts();
 
-    ASSERTMSG1LINE("OSThread.c", 0x33B, __OSIsThreadActive(thread) == 0L, "OSCreateThread(): thread %p is still active.", thread);
+    ASSERTMSG1LINE(0x33B, __OSIsThreadActive(thread) == 0L, "OSCreateThread(): thread %p is still active.", thread);
 
     ENQUEUE_THREAD(thread, &__OSActiveThreadQueue, linkActive);
 
@@ -452,11 +452,11 @@ void OSExitThread(void * val) {
     int enabled = OSDisableInterrupts();
     struct OSThread * currentThread = OSGetCurrentThread();
 
-    ASSERTMSGLINE("OSThread.c", 0x354, currentThread, 
+    ASSERTMSGLINE(0x354, currentThread, 
         "OSExitThread(): current thread does not exist.");
-    ASSERTMSGLINE("OSThread.c", 0x356, currentThread->state == 2, 
+    ASSERTMSGLINE(0x356, currentThread->state == 2, 
         "OSExitThread(): current thread is not running.");
-    ASSERTMSGLINE("OSThread.c", 0x358, __OSIsThreadActive(currentThread) != 0, 
+    ASSERTMSGLINE(0x358, __OSIsThreadActive(currentThread) != 0, 
         "OSExitThread(): current thread is not active.");
 
     OSClearContext(&currentThread->context);
@@ -483,7 +483,7 @@ void OSExitThread(void * val) {
 void OSCancelThread(struct OSThread * thread) {
     int enabled = OSDisableInterrupts();
 
-    ASSERTMSG1LINE("OSThread.c", 0x37E, __OSIsThreadActive(thread) != 0, 
+    ASSERTMSG1LINE(0x37E, __OSIsThreadActive(thread) != 0, 
         "OSExitThread(): thread %p is not active.", thread);
 
     switch(thread->state) {
@@ -499,7 +499,7 @@ void OSCancelThread(struct OSThread * thread) {
             DEQUEUE_THREAD(thread, thread->queue, link);
             thread->queue = 0;
             if ((thread->suspend <= 0) && (thread->mutex)) {
-                ASSERTLINE("OSThread.c", 0x391, thread->mutex->thread);
+                ASSERTLINE(0x391, thread->mutex->thread);
                 UpdatePriority(thread->mutex->thread);
             }
             break;
@@ -523,7 +523,7 @@ void OSCancelThread(struct OSThread * thread) {
 int OSJoinThread(struct OSThread * thread, void * val) {
     int enabled = OSDisableInterrupts();
 
-    ASSERTMSG1LINE("OSThread.c", 0x3CA, __OSIsThreadActive(thread) != 0, "OSJoinThread(): thread %p is not active.", thread);
+    ASSERTMSG1LINE(0x3CA, __OSIsThreadActive(thread) != 0, "OSJoinThread(): thread %p is not active.", thread);
 
     if (!(thread->attr & 1) && (thread->state != 8) && (thread->queueJoin.head == NULL)) {
         OSSleepThread(&thread->queueJoin);
@@ -548,7 +548,7 @@ int OSJoinThread(struct OSThread * thread, void * val) {
 void OSDetachThread(struct OSThread * thread) {
     int enabled = OSDisableInterrupts();
 
-    ASSERTMSG1LINE("OSThread.c", 0x3FC, __OSIsThreadActive(thread) != 0, "OSDetachThread(): thread %p is not active.", thread);
+    ASSERTMSG1LINE(0x3FC, __OSIsThreadActive(thread) != 0, "OSDetachThread(): thread %p is not active.", thread);
     
     thread->attr |= 1;
     if (thread->state == 8) {
@@ -563,8 +563,8 @@ long OSResumeThread(struct OSThread * thread) {
     int enabled = OSDisableInterrupts();
     long suspendCount;
 
-    ASSERTMSG1LINE("OSThread.c", 0x419, __OSIsThreadActive(thread) != 0, "OSResumeThread(): thread %p is not active.", thread);
-    ASSERTMSG1LINE("OSThread.c", 0x41B, thread->state != 8, "OSResumeThread(): thread %p is terminated.", thread);
+    ASSERTMSG1LINE(0x419, __OSIsThreadActive(thread) != 0, "OSResumeThread(): thread %p is not active.", thread);
+    ASSERTMSG1LINE(0x41B, thread->state != 8, "OSResumeThread(): thread %p is terminated.", thread);
 
     suspendCount = thread->suspend--;
     if (thread->suspend < 0) {
@@ -576,7 +576,7 @@ long OSResumeThread(struct OSThread * thread) {
                 SetRun(thread);
                 break;
             case 4:
-                ASSERTLINE("OSThread.c", 0x42A, thread->queue);
+                ASSERTLINE(0x42A, thread->queue);
                 DEQUEUE_THREAD(thread, thread->queue, link);
                 thread->priority = __OSGetEffectivePriority(thread);
                 ENQUEUE_THREAD_PRIO(thread, thread->queue, link);
@@ -594,8 +594,8 @@ long OSSuspendThread(struct OSThread * thread) {
     int enabled = OSDisableInterrupts();
     long suspendCount;
 
-    ASSERTMSG1LINE("OSThread.c", 0x44C, __OSIsThreadActive(thread) != 0, "OSSuspendThread(): thread %p is not active.", thread);
-    ASSERTMSG1LINE("OSThread.c", 0x44E, thread->state != 8, "OSSuspendThread(): thread %p is terminated.", thread);
+    ASSERTMSG1LINE(0x44C, __OSIsThreadActive(thread) != 0, "OSSuspendThread(): thread %p is not active.", thread);
+    ASSERTMSG1LINE(0x44E, thread->state != 8, "OSSuspendThread(): thread %p is terminated.", thread);
 
     suspendCount = thread->suspend++;
     if (suspendCount == 0) {
@@ -612,7 +612,7 @@ long OSSuspendThread(struct OSThread * thread) {
                 thread->priority = 0x20;
                 ENQUEUE_THREAD(thread, thread->queue, link);
                 if (thread->mutex) {
-                    ASSERTLINE("OSThread.c", 0x463, thread->mutex->thread); 
+                    ASSERTLINE(0x463, thread->mutex->thread); 
                     UpdatePriority(thread->mutex->thread);
                 }
                 break;
@@ -627,10 +627,10 @@ void OSSleepThread(struct OSThreadQueue * queue) {
     int enabled = OSDisableInterrupts();
     struct OSThread * currentThread = OSGetCurrentThread();
 
-    ASSERTMSGLINE("OSThread.c", 0x484, currentThread, "OSSleepThread(): current thread does not exist.");
-    ASSERTMSG1LINE("OSThread.c", 0x486, __OSIsThreadActive(currentThread) != 0, "OSSleepThread(): current thread %p is not active.", currentThread);
-    ASSERTMSG1LINE("OSThread.c", 0x488, currentThread->state == 2, "OSSleepThread(): current thread %p is not running.", currentThread);
-    ASSERTMSG1LINE("OSThread.c", 0x48A, currentThread->suspend <= 0, "OSSleepThread(): current thread %p is suspended.", currentThread);
+    ASSERTMSGLINE(0x484, currentThread, "OSSleepThread(): current thread does not exist.");
+    ASSERTMSG1LINE(0x486, __OSIsThreadActive(currentThread) != 0, "OSSleepThread(): current thread %p is not active.", currentThread);
+    ASSERTMSG1LINE(0x488, currentThread->state == 2, "OSSleepThread(): current thread %p is not running.", currentThread);
+    ASSERTMSG1LINE(0x48A, currentThread->suspend <= 0, "OSSleepThread(): current thread %p is suspended.", currentThread);
 
     currentThread->state = 4;
     currentThread->queue = queue;
@@ -648,9 +648,9 @@ void OSWakeupThread(struct OSThreadQueue * queue) {
 
         DEQUEUE_HEAD(thread, queue, link);
 
-        ASSERTLINE("OSThread.c", 0x4A7, __OSIsThreadActive(thread));
-        ASSERTLINE("OSThread.c", 0x4A8, thread->state != OS_THREAD_STATE_MORIBUND);
-        ASSERTLINE("OSThread.c", 0x4A9, thread->queue == queue);
+        ASSERTLINE(0x4A7, __OSIsThreadActive(thread));
+        ASSERTLINE(0x4A8, thread->state != OS_THREAD_STATE_MORIBUND);
+        ASSERTLINE(0x4A9, thread->queue == queue);
         thread->state = 1;
         if (thread->suspend <= 0) {
             SetRun(thread);
@@ -663,15 +663,15 @@ void OSWakeupThread(struct OSThreadQueue * queue) {
 int OSSetThreadPriority(struct OSThread * thread, long priority) {
     int enabled;
 
-    ASSERTMSGLINE("OSThread.c", 0x4C3, (priority >= 0) && (priority <= 0x1F), "OSSetThreadPriority(): priority out of range (0 <= priority <= 31).");
+    ASSERTMSGLINE(0x4C3, (priority >= 0) && (priority <= 0x1F), "OSSetThreadPriority(): priority out of range (0 <= priority <= 31).");
 
     if ((priority < 0) || (priority > 0x1F)) {
         return 0;
     }
     enabled = OSDisableInterrupts();
 
-    ASSERTMSG1LINE("OSThread.c", 0x4CA, __OSIsThreadActive(thread) != 0, "OSSetThreadPriority(): thread %p is not active.", thread);
-    ASSERTMSG1LINE("OSThread.c", 0x4CC, thread->state != 8, "OSSetThreadPriority(): thread %p is terminated.", thread);
+    ASSERTMSG1LINE(0x4CA, __OSIsThreadActive(thread) != 0, "OSSetThreadPriority(): thread %p is not active.", thread);
+    ASSERTMSG1LINE(0x4CC, thread->state != 8, "OSSetThreadPriority(): thread %p is terminated.", thread);
 
     if (thread->base != priority) {
         thread->base = priority;
@@ -741,10 +741,10 @@ static int IsMember(struct OSThreadQueue * queue, struct OSThread * thread) {
 }
 
 // custom macro for OSCheckActiveThreads?
-#define ASSERTREPORT(file, line, cond) \
+#define ASSERTREPORT(line, cond) \
     if (!(cond)) { \
         OSReport("OSCheckActiveThreads: Failed " #cond " in %d\n", line); \
-        OSPanic(file, line, ""); \
+        OSPanic(__FILE__, line, ""); \
     }
 
 long OSCheckActiveThreads() {
@@ -758,58 +758,58 @@ long OSCheckActiveThreads() {
     
     for(prio = 0; prio <= 0x1F; prio++) {
         if (RunQueueBits & (1 << (0x1F - prio))) {
-            ASSERTREPORT("OSThread.c", 0x566, RunQueue[prio].head != NULL && RunQueue[prio].tail != NULL);
+            ASSERTREPORT(0x566, RunQueue[prio].head != NULL && RunQueue[prio].tail != NULL);
         } else {
-            ASSERTREPORT("OSThread.c", 0x56B, RunQueue[prio].head == NULL && RunQueue[prio].tail == NULL);
+            ASSERTREPORT(0x56B, RunQueue[prio].head == NULL && RunQueue[prio].tail == NULL);
         }
-        ASSERTREPORT("OSThread.c", 0x56D, CheckThreadQueue(&RunQueue[prio]));
+        ASSERTREPORT(0x56D, CheckThreadQueue(&RunQueue[prio]));
     }
 
-    ASSERTREPORT("OSThread.c", 0x572, __OSActiveThreadQueue.head == NULL || __OSActiveThreadQueue.head->linkActive.prev == NULL);
-    ASSERTREPORT("OSThread.c", 0x574, __OSActiveThreadQueue.tail == NULL || __OSActiveThreadQueue.tail->linkActive.next == NULL);
+    ASSERTREPORT(0x572, __OSActiveThreadQueue.head == NULL || __OSActiveThreadQueue.head->linkActive.prev == NULL);
+    ASSERTREPORT(0x574, __OSActiveThreadQueue.tail == NULL || __OSActiveThreadQueue.tail->linkActive.next == NULL);
 
     thread = __OSActiveThreadQueue.head;
     while(thread) {
         cThread++;
-        ASSERTREPORT("OSThread.c", 0x57C, thread->linkActive.next == NULL || thread == thread->linkActive.next->linkActive.prev);
-        ASSERTREPORT("OSThread.c", 0x57E, thread->linkActive.prev == NULL || thread == thread->linkActive.prev->linkActive.next);
-        ASSERTREPORT("OSThread.c", 0x581, *(thread->stackEnd) == OS_THREAD_STACK_MAGIC);
-        ASSERTREPORT("OSThread.c", 0x584, OS_PRIORITY_MIN <= thread->priority && thread->priority <= OS_PRIORITY_MAX+1);
-        ASSERTREPORT("OSThread.c", 0x585, 0 <= thread->suspend);
-        ASSERTREPORT("OSThread.c", 0x586, CheckThreadQueue(&thread->queueJoin));
+        ASSERTREPORT(0x57C, thread->linkActive.next == NULL || thread == thread->linkActive.next->linkActive.prev);
+        ASSERTREPORT(0x57E, thread->linkActive.prev == NULL || thread == thread->linkActive.prev->linkActive.next);
+        ASSERTREPORT(0x581, *(thread->stackEnd) == OS_THREAD_STACK_MAGIC);
+        ASSERTREPORT(0x584, OS_PRIORITY_MIN <= thread->priority && thread->priority <= OS_PRIORITY_MAX+1);
+        ASSERTREPORT(0x585, 0 <= thread->suspend);
+        ASSERTREPORT(0x586, CheckThreadQueue(&thread->queueJoin));
 
         switch(thread->state) {
             case 1:
                 if (thread->suspend <= 0) {
-                    ASSERTREPORT("OSThread.c", 0x58C, thread->queue == &RunQueue[thread->priority]);
-                    ASSERTREPORT("OSThread.c", 0x58D, IsMember(&RunQueue[thread->priority], thread));
-                    ASSERTREPORT("OSThread.c", 0x58E, thread->priority == __OSGetEffectivePriority(thread));
+                    ASSERTREPORT(0x58C, thread->queue == &RunQueue[thread->priority]);
+                    ASSERTREPORT(0x58D, IsMember(&RunQueue[thread->priority], thread));
+                    ASSERTREPORT(0x58E, thread->priority == __OSGetEffectivePriority(thread));
                 }
                 break;
             case 2:
-                ASSERTREPORT("OSThread.c", 0x592, !IsSuspended(thread->suspend));
-                ASSERTREPORT("OSThread.c", 0x593, thread->queue == NULL);
-                ASSERTREPORT("OSThread.c", 0x594, thread->priority == __OSGetEffectivePriority(thread));
+                ASSERTREPORT(0x592, !IsSuspended(thread->suspend));
+                ASSERTREPORT(0x593, thread->queue == NULL);
+                ASSERTREPORT(0x594, thread->priority == __OSGetEffectivePriority(thread));
                 break;
             case 4:
-                ASSERTREPORT("OSThread.c", 0x597, thread->queue != NULL);
-                ASSERTREPORT("OSThread.c", 0x598, CheckThreadQueue(thread->queue));
-                ASSERTREPORT("OSThread.c", 0x599, IsMember(thread->queue, thread));
+                ASSERTREPORT(0x597, thread->queue != NULL);
+                ASSERTREPORT(0x598, CheckThreadQueue(thread->queue));
+                ASSERTREPORT(0x599, IsMember(thread->queue, thread));
                 if (thread->suspend <= 0) {
-                    ASSERTREPORT("OSThread.c", 0x59C, thread->priority == __OSGetEffectivePriority(thread));
+                    ASSERTREPORT(0x59C, thread->priority == __OSGetEffectivePriority(thread));
                 } else {
-                    ASSERTREPORT("OSThread.c", 0x5A0, thread->priority == 32);
+                    ASSERTREPORT(0x5A0, thread->priority == 32);
                 }
-                ASSERTREPORT("OSThread.c", 0x5A2, !__OSCheckDeadLock(thread));
+                ASSERTREPORT(0x5A2, !__OSCheckDeadLock(thread));
                 break;
             case 8:
-                ASSERTREPORT("OSThread.c", 0x5A6, thread->queueMutex.head == NULL && thread->queueMutex.tail == NULL);
+                ASSERTREPORT(0x5A6, thread->queueMutex.head == NULL && thread->queueMutex.tail == NULL);
                 break;
             default:
                 OSReport("OSCheckActiveThreads: Failed. unkown thread state (%d) of thread %p\n", thread->state, thread);
                 OSPanic("OSThread.c", 0x5AC, "");
         }
-        ASSERTREPORT("OSThread.c", 0x5B1, __OSCheckMutexes(thread));
+        ASSERTREPORT(0x5B1, __OSCheckMutexes(thread));
         thread = thread->linkActive.next;
     }
     OSRestoreInterrupts(enabled);

--- a/src/os/OSTime.c
+++ b/src/os/OSTime.c
@@ -90,7 +90,7 @@ static int GetYearDays(int year, int mon) {
 }
 
 static int GetLeapDays(int year) {
-    ASSERTLINE("OSTime.c", 260, 0 <= year);
+    ASSERTLINE(260, 0 <= year);
     
     if (year < 1) {
         return 0;
@@ -104,7 +104,7 @@ static void GetDates(int days, OSCalendarTime* td) {
     int month;
     int * md;
 
-    ASSERTLINE("OSTime.c", 285, 0 <= days);
+    ASSERTLINE(285, 0 <= days);
 
     td->wday = (days + 6) % WEEK_DAY_MAX;
 
@@ -133,26 +133,26 @@ void OSTicksToCalendarTime(long long ticks, OSCalendarTime* td) {
     d = ticks % OS_SEC_TO_TICKS(1);    
     if (d < 0) {
         d += OS_SEC_TO_TICKS(1);
-        ASSERTLINE("OSTime.c", 330, 0 <= d);
+        ASSERTLINE(330, 0 <= d);
     }
 
     td->usec = OS_TICKS_TO_USEC(d) % USEC_MAX;
     td->msec = OS_TICKS_TO_MSEC(d) % MSEC_MAX;
 
-    ASSERTLINE("OSTime.c", 334, 0 <= td->usec);
-    ASSERTLINE("OSTime.c", 335, 0 <= td->msec);
+    ASSERTLINE(334, 0 <= td->usec);
+    ASSERTLINE(335, 0 <= td->msec);
 
     ticks -= d;
 
-    ASSERTLINE("OSTime.c", 338, ticks % OSSecondsToTicks(1) == 0);
-    ASSERTLINE("OSTime.c", 342, 0 <= OSTicksToSeconds(ticks) / 86400 + BIAS && OSTicksToSeconds(ticks) / 86400 + BIAS <= INT_MAX);
+    ASSERTLINE(338, ticks % OSSecondsToTicks(1) == 0);
+    ASSERTLINE(342, 0 <= OSTicksToSeconds(ticks) / 86400 + BIAS && OSTicksToSeconds(ticks) / 86400 + BIAS <= INT_MAX);
 
     days = (OS_TICKS_TO_SEC(ticks) / SECS_IN_DAY) + BIAS;    
     secs = OS_TICKS_TO_SEC(ticks) % SECS_IN_DAY;
     if (secs < 0) {
         days -= 1;
         secs += SECS_IN_DAY;
-        ASSERTLINE("OSTime.c", 349, 0 <= secs);
+        ASSERTLINE(349, 0 <= secs);
     }
 
     GetDates(days, td);
@@ -175,7 +175,7 @@ long long OSCalendarTimeToTicks(struct OSCalendarTime* td) {
         ov_mon--;
     }
 
-    ASSERTLINE("OSTime.c", 0x182, (ov_mon <= 0 && 0 <= td->year + ov_mon) || (0 < ov_mon && td->year <= INT_MAX - ov_mon));
+    ASSERTLINE(0x182, (ov_mon <= 0 && 0 <= td->year + ov_mon) || (0 < ov_mon && td->year <= INT_MAX - ov_mon));
     
     year = td->year + ov_mon;
 


### PR DESCRIPTION
I don't have a way to quickly check that _everything_ matches, but nothing should have changed with regards to that.